### PR TITLE
Not consume Item while in Creative

### DIFF
--- a/src/main/java/baubles/common/items/ItemRing.java
+++ b/src/main/java/baubles/common/items/ItemRing.java
@@ -62,7 +62,9 @@ public class ItemRing  extends Item implements IBauble
 			for(int i = 0; i < baubles.getSizeInventory(); i++)
 				if(baubles.getStackInSlot(i) == null && baubles.isItemValidForSlot(i, par1ItemStack)) {
 					baubles.setInventorySlotContents(i, par1ItemStack.copy());
-					par3EntityPlayer.inventory.setInventorySlotContents(par3EntityPlayer.inventory.currentItem, null);
+					if(!par3EntityPlayer.capabilities.isCreativeMode){
+						par3EntityPlayer.inventory.setInventorySlotContents(par3EntityPlayer.inventory.currentItem, null);
+					}
 					onEquipped(par1ItemStack, par3EntityPlayer);
 					break;
 				}


### PR DESCRIPTION
Changes the condition of making the item null on use so that player's in creative don't loose the item upon right click. Similar to how vanilla handles armor.
