### PR TITLE
Use LivingDropsEvent instead of LivingDeathEvent

### DIFF
--- a/src/main/java/baubles/common/event/EventHandlerEntity.java
+++ b/src/main/java/baubles/common/event/EventHandlerEntity.java
@@ -19,8 +19,9 @@ public class EventHandlerEntity  {
 			
 			InventoryBaubles baubles = PlayerHandler.getPlayerBaubles(player);
 			for (int a=0;a<baubles.getSizeInventory();a++) {
-				if (baubles.getStackInSlot(a)!=null && baubles.getStackInSlot(a).getItem() instanceof IBauble) {
-					((IBauble)baubles.getStackInSlot(a).getItem()).onWornTick(baubles.getStackInSlot(a), player);
+				ItemStack bauble = baubles.getStackInSlot(a);
+				if (bauble!=null && bauble.getItem() instanceof IBauble) {
+					((IBauble)bauble.getItem()).onWornTick(bauble, player);
 				}
 			}
 			
@@ -29,10 +30,17 @@ public class EventHandlerEntity  {
 	}
 	
 	@SubscribeEvent
-	public void playerDeath(LivingDeathEvent event) {
+	public void playerDeath(LivingDropsEvent event) {
 		if (event.entity instanceof EntityPlayer && !event.entity.worldObj.isRemote) {
 			EntityPlayer player = (EntityPlayer)event.entity;
-			PlayerHandler.getPlayerBaubles(player).dropItems(player);
+			
+			InventoryBaubles baubles = PlayerHandler.getPlayerBaubles(player);
+			for (int a=0;a<baubles.getSizeInventory();a++) {
+				ItemStack bauble = baubles.getStackInSlot(a);
+				if (bauble!=null) {
+					drops.add(bauble);
+				}
+			}
 		}
 	}
 		


### PR DESCRIPTION
Alternative solution to #22.

With this change, the items will get added to the list of items to be dropped on death. As long as LivingDropsEvent isn't cancelled, the items will be dropped like everything else.

**Notes:**
- InventoryBaubles.dropItems not necessary anymore?
- Use PlayerDropsEvent instead, if Baubles are Player-only anyway? (Gets rid of instanceof check.)
- Maybe use higher priority than the default?
- Tried to keep the coding style the same, but added a little optimization.
- Did not test beforehand, change was done on GitHub website.
