### PR TITLE
Standardise artifacts format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,25 +45,25 @@ processResources
 
 // Create deobf dev jars
 task deobfJar(type: Jar) {
-    from(sourceSets.main.output) {
-        appendix = 'deobf' 
-    }
-} 
+    from sourceSets.main.output
+    classifier = 'deobf'
+}
 
 // Create API library zip
-task apiZip(type: Zip) {   
-    from(sourceSets.main.java) {        
-        include "baubles/api/**"    
-     }    
-     classifier = 'api'
+task apiJar(type: Jar) {
+    from(sourceSets.main.java) {
+        include "baubles/api/**"
+    }
+    classifier = 'api'
 }
 
-apiZip.mustRunAfter deobfJar
-
-
-artifacts { 
-    archives deobfJar 
-    archives apiZip
+task sourcesJar(type: Jar) {
+    from sourceSets.main.allSource
+    classifier = 'sources'
 }
 
-
+artifacts {
+    archives deobfJar
+    archives apiJar
+    archives sourcesJar
+}


### PR DESCRIPTION
- You should almost never use an appendix on your artifacts, this becomes clear when you start using maven.
- APIs - even the source - are normally distributed in jar files. I can change this back if you think it is important.
- If you include a jar named "sources" with the full source of a project, IDEs can pick this up and make the source available to browse through if you are using maven.
