### PR TITLE
1.7.10

### DIFF
--- a/src/main/java/baubles/common/Config.java
+++ b/src/main/java/baubles/common/Config.java
@@ -12,7 +12,10 @@ public class Config {
 	
 	public static Configuration config;
 	public static Item itemRing;
-		
+	
+    // config properties
+    private static boolean splitSurvivalCreative = false;
+	
 	public static void initialize(File file)
     {
 		config = new Configuration(file);
@@ -21,6 +24,8 @@ public class Config {
         itemRing =(new ItemRing()).setUnlocalizedName("Ring");
 		GameRegistry.registerItem(itemRing, "Ring", Baubles.MODID);        
         
+		splitSurvivalCreative = config.getBoolean("splitSurvivalCreative", "server", splitSurvivalCreative, "Split Baubles inventory for survival and creative game modes.");
+		
         //save it
 		config.save();
     }
@@ -39,7 +44,7 @@ public class Config {
 //					Character.valueOf('P'), new ItemStack(Items.potionitem,1,8226)});
 	}
 	
-
-	
-	
+    public static boolean isSplitSurvivalCreative() {
+        return splitSurvivalCreative;
+    }
 }

--- a/src/main/java/baubles/common/event/EventHandlerEntity.java
+++ b/src/main/java/baubles/common/event/EventHandlerEntity.java
@@ -2,6 +2,8 @@ package baubles.common.event;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraftforge.event.entity.player.PlayerDropsEvent;
@@ -10,6 +12,7 @@ import baubles.api.IBauble;
 import baubles.common.Baubles;
 import baubles.common.container.InventoryBaubles;
 import baubles.common.lib.PlayerHandler;
+import baubles.common.Config;
 
 import com.google.common.io.Files;
 
@@ -17,13 +20,38 @@ import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 
 public class EventHandlerEntity {
 
+	// player directory
+	private File playerDirectory;
+	
+	// hash containing game mode of all players
+	private Map<String,Boolean> playerModes = new HashMap<String,Boolean>();
+	
 	@SubscribeEvent
 	public void playerTick(PlayerEvent.LivingUpdateEvent event) {
 
 		// player events
 		if (event.entity instanceof EntityPlayer) {
 			EntityPlayer player = (EntityPlayer) event.entity;
-
+			
+			if (Config.isSplitSurvivalCreative()) {
+				// detect game mode changes
+				if (playerModes.containsKey(player.getCommandSenderName()) && (playerDirectory != null))
+				{
+					Boolean mode = playerModes.get(player.getCommandSenderName());
+					if (mode && !player.capabilities.isCreativeMode)
+					{
+						playerSaveDo(player, playerDirectory, true);
+						playerLoadDo(player, playerDirectory, false);
+					}
+					else if (!mode && player.capabilities.isCreativeMode)
+					{
+						playerSaveDo(player, playerDirectory, false);
+						playerLoadDo(player, playerDirectory, true);
+					}
+				}
+				playerModes.put(player.getCommandSenderName(), player.capabilities.isCreativeMode);
+			}
+			
 			InventoryBaubles baubles = PlayerHandler.getPlayerBaubles(player);
 			for (int a = 0; a < baubles.getSizeInventory(); a++) {
 				if (baubles.getStackInSlot(a) != null
@@ -51,38 +79,64 @@ public class EventHandlerEntity {
 
 	@SubscribeEvent
 	public void playerLoad(PlayerEvent.LoadFromFile event) {
-		PlayerHandler.clearPlayerBaubles(event.entityPlayer);
+		playerLoadDo(event.entityPlayer, event.playerDirectory, event.entityPlayer.capabilities.isCreativeMode);
+		playerDirectory = event.playerDirectory;
+	}
+	
+	private void playerLoadDo(EntityPlayer player, File directory, Boolean gamemode) {
+		PlayerHandler.clearPlayerBaubles(player);
 		
-		File file1 = getPlayerFile("baub", event.playerDirectory, event.entityPlayer.getCommandSenderName());
+		File file1, file2;
+		String fileName, fileNameBackup;
+		if (gamemode || !Config.isSplitSurvivalCreative()) {
+			fileName = "baub";
+			fileNameBackup = "baubback";
+		}
+		else {
+			fileName = "baubs";
+			fileNameBackup = "baubsback";
+		}
+		
+		// look for normal files first
+		file1 = getPlayerFile(fileName, directory, player.getCommandSenderName());
+		file2 = getPlayerFile(fileNameBackup, directory, player.getCommandSenderName());
+		
+		// look for uuid files when normal file missing
 		if (!file1.exists()) {
-			File filep = event.getPlayerFile("baub");
+			File filep = getPlayerFileUUID(fileName, directory, player.getGameProfile().getId().toString());
 			if (filep.exists()) {
 				try {
 					Files.copy(filep, file1);					
-					Baubles.log.info("Using and converting UUID Baubles savefile for "+event.entityPlayer.getCommandSenderName());
+					Baubles.log.info("Using and converting UUID Baubles savefile for "+player.getCommandSenderName());
 					filep.delete();
-					File fb = event.getPlayerFile("baubback");
+					File fb = getPlayerFileUUID(fileNameBackup, directory, player.getGameProfile().getId().toString());
 					if (fb.exists()) fb.delete();					
 				} catch (IOException e) {}
 			} else {
-				File filet = getLegacyFileFromPlayer(event.entityPlayer);
+				File filet = getLegacyFileFromPlayer(player);
 				if (filet.exists()) {
 					try {
 						Files.copy(filet, file1);
-						Baubles.log.info("Using pre MC 1.7.10 Baubles savefile for "+event.entityPlayer.getCommandSenderName());
+						Baubles.log.info("Using pre MC 1.7.10 Baubles savefile for "+player.getCommandSenderName());
 					} catch (IOException e) {}
 				}
 			}
 		}
 		
-		PlayerHandler.loadPlayerBaubles(event.entityPlayer, file1, getPlayerFile("baubback", event.playerDirectory, event.entityPlayer.getCommandSenderName()));
-		EventHandlerNetwork.syncBaubles(event.entityPlayer);
+		PlayerHandler.loadPlayerBaubles(player, file1, file2);
+		EventHandlerNetwork.syncBaubles(player);
 	}
 	
 	public File getPlayerFile(String suffix, File playerDirectory, String playername)
     {
         if ("dat".equals(suffix)) throw new IllegalArgumentException("The suffix 'dat' is reserved");
         return new File(playerDirectory, playername+"."+suffix);
+    }
+	
+	public File getPlayerFileUUID(String suffix, File playerDirectory, String playerUUID)
+    {
+        if ("dat".equals(suffix)) throw new IllegalArgumentException("The suffix 'dat' is reserved");
+        return new File(playerDirectory, playerUUID+"."+suffix);
     }
 	
 	public static File getLegacyFileFromPlayer(EntityPlayer player)
@@ -96,9 +150,20 @@ public class EventHandlerEntity {
 
 	@SubscribeEvent
 	public void playerSave(PlayerEvent.SaveToFile event) {
-		PlayerHandler.savePlayerBaubles(event.entityPlayer, 
-				getPlayerFile("baub", event.playerDirectory, event.entityPlayer.getCommandSenderName()), 
-				getPlayerFile("baubback", event.playerDirectory, event.entityPlayer.getCommandSenderName()));
+		playerSaveDo(event.entityPlayer, event.playerDirectory, event.entityPlayer.capabilities.isCreativeMode);
+	}
+	
+	private void playerSaveDo(EntityPlayer player, File directory, Boolean gamemode) {
+		if (gamemode || !Config.isSplitSurvivalCreative()) {
+			PlayerHandler.savePlayerBaubles(player, 
+					getPlayerFile("baub", directory, player.getCommandSenderName()), 
+					getPlayerFile("baubback", directory, player.getCommandSenderName()));
+		}
+		else {
+			PlayerHandler.savePlayerBaubles(player, 
+					getPlayerFile("baubs", directory, player.getCommandSenderName()), 
+					getPlayerFile("baubsback", directory, player.getCommandSenderName()));
+		}
 	}
 
 }


### PR DESCRIPTION
Added support to store and load separate bauble inventories when switching beween creative and survival game mode. Otherwise when using this mod on a server with multiple worlds (for instance Cauldron with Multiverse plugin), players can transport baubles from creative worlds to survival worlds.
