### PR TITLE
Changed bauble save files from using player names to ID & Server crash fix

### DIFF
--- a/src/main/java/baubles/client/ClientProxy.java
+++ b/src/main/java/baubles/client/ClientProxy.java
@@ -1,7 +1,10 @@
 
 package baubles.client;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.WorldClient;
+import net.minecraft.client.resources.model.ModelBakery;
+import net.minecraft.client.resources.model.ModelResourceLocation;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
@@ -11,6 +14,7 @@ import baubles.client.gui.GuiEvents;
 import baubles.client.gui.GuiPlayerExpanded;
 import baubles.common.Baubles;
 import baubles.common.CommonProxy;
+import baubles.common.Config;
 import baubles.common.event.KeyHandler;
 
 public class ClientProxy extends CommonProxy {
@@ -33,6 +37,12 @@ public class ClientProxy extends CommonProxy {
 			}
 		}
 		return null;
+	}
+	
+	@Override 
+	public void registerTextures(){
+		Minecraft.getMinecraft().getRenderItem().getItemModelMesher().register(Config.itemRing, 0, new ModelResourceLocation(Baubles.MODID + ":ring", "inventory"));
+		ModelBakery.addVariantName(Config.itemRing, Baubles.MODID + ":ring");
 	}
 				
 	@Override

--- a/src/main/java/baubles/common/Baubles.java
+++ b/src/main/java/baubles/common/Baubles.java
@@ -14,6 +14,10 @@ import net.minecraftforge.fml.common.SidedProxy;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLServerAboutToStartEvent;
+import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
+import net.minecraftforge.fml.common.event.FMLServerStoppedEvent;
+import net.minecraftforge.fml.common.event.FMLServerStoppingEvent;
 import net.minecraftforge.fml.common.network.NetworkRegistry;
 
 import org.apache.logging.log4j.LogManager;
@@ -42,6 +46,22 @@ public class Baubles {
 	
 	public static final Logger log = LogManager.getLogger("Baubles");
 	public static final int GUI = 0;
+	
+	@EventHandler
+	public void serverPreStart(FMLServerAboutToStartEvent event) {
+		Config.loadBaublesID();
+	}
+	
+	@EventHandler
+	public void serverStop(FMLServerStoppedEvent event) {
+		Config.saveBaublesID();
+	}
+	
+	public File getPlayerFile(String suffix, File playerDirectory, String playername)
+    {
+        if ("dat".equals(suffix)) throw new IllegalArgumentException("The suffix 'dat' is reserved");
+        return new File(playerDirectory, playername+"."+suffix);
+    }
 	
 	@EventHandler
 	public void preInit(FMLPreInitializationEvent event) {

--- a/src/main/java/baubles/common/Baubles.java
+++ b/src/main/java/baubles/common/Baubles.java
@@ -93,8 +93,7 @@ public class Baubles {
 
 	@EventHandler
 	public void init(FMLInitializationEvent evt) {
-		Minecraft.getMinecraft().getRenderItem().getItemModelMesher().register(Config.itemRing, 0, new ModelResourceLocation(Baubles.MODID + ":ring", "inventory"));
-		ModelBakery.addVariantName(Config.itemRing, Baubles.MODID + ":ring");
+		proxy.registerTextures();
 		NetworkRegistry.INSTANCE.registerGuiHandler(instance, proxy);
   		proxy.registerKeyBindings();
 	}

--- a/src/main/java/baubles/common/CommonProxy.java
+++ b/src/main/java/baubles/common/CommonProxy.java
@@ -47,4 +47,6 @@ public class CommonProxy implements IGuiHandler {
 	public static NBTTagCompound getBaublesID(String name){
 	return baublesIDData.remove(name);
 	}
+
+	public void registerTextures() {}
 }

--- a/src/main/java/baubles/common/CommonProxy.java
+++ b/src/main/java/baubles/common/CommonProxy.java
@@ -1,7 +1,11 @@
 
 package baubles.common;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.common.network.IGuiHandler;
 import baubles.common.container.ContainerPlayerExpanded;
@@ -12,6 +16,8 @@ public class CommonProxy implements IGuiHandler {
 	public KeyHandler keyHandler;
 	
 	public void registerHandlers() {}
+	
+	private static final Map<String, NBTTagCompound> baublesIDData = new HashMap<String, NBTTagCompound>();
 	
 
 	@Override
@@ -33,5 +39,12 @@ public class CommonProxy implements IGuiHandler {
 		
 	
 	public void registerKeyBindings() {}
+	
+	public static void storeBaublesID(String name, NBTTagCompound compound){
+		baublesIDData.put(name, compound);
+	}
 
+	public static NBTTagCompound getBaublesID(String name){
+	return baublesIDData.remove(name);
+	}
 }

--- a/src/main/java/baubles/common/Config.java
+++ b/src/main/java/baubles/common/Config.java
@@ -1,8 +1,14 @@
 package baubles.common;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.item.Item;
+import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.server.integrated.IntegratedServer;
+import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import baubles.common.items.ItemRing;
@@ -11,6 +17,7 @@ public class Config {
 	
 	public static Configuration config;
 	public static Item itemRing;
+	private static int nextInventoryID = 0;
 		
 	public static void initialize(File file)
     {
@@ -23,7 +30,47 @@ public class Config {
 		//save it
 		config.save();
     }
-
+	
+	public static void loadBaublesID() {
+		File file = new File(DimensionManager.getCurrentSaveRootDirectory(), "BaublesCount.baub");
+		try{
+			if (file.exists() && file != null){
+				Baubles.log.info("Reading Baubles ID list");
+				FileInputStream fileinputstream = new FileInputStream(file);
+				nextInventoryID = fileinputstream.read();
+				fileinputstream.close();
+				}
+			else{
+				Baubles.log.info("Creating Baubles ID list");
+				saveBaublesID();
+			}
+		}catch(Exception e) {
+			Baubles.log.error("An error ocurred while reading Baubles ID count, resetting", e);
+		}
+	}
+	
+	public static void saveBaublesID() {
+		File file = new File(DimensionManager.getCurrentSaveRootDirectory(), "BaublesCount.baub");
+		try{
+			if(file.exists()){
+				file.delete();
+			}
+			FileOutputStream fileoutputstream = new FileOutputStream(file);
+			fileoutputstream.write(nextInventoryID);
+			fileoutputstream.close();
+		}catch(Exception e){
+			Baubles.log.fatal("An error ocurred while saving Baubles ID count!", e);
+		}
+	}
+	
+	public static void addBaublesID() {
+		nextInventoryID++;
+		saveBaublesID();
+	}
+	
+	public static int getNewBaublesID() {
+		return nextInventoryID;
+	}
 	
 	public static void save()
     {

--- a/src/main/java/baubles/common/event/EventHandlerEntity.java
+++ b/src/main/java/baubles/common/event/EventHandlerEntity.java
@@ -58,7 +58,7 @@ public class EventHandlerEntity {
 	public void playerLoad(PlayerEvent.LoadFromFile event) {
 		PlayerHandler.clearPlayerBaubles(event.entityPlayer);
 		
-		File file1 = getPlayerFile("baub", event.playerDirectory, "baublesNO" + BaublesIDHandler.get(event.entityPlayer).getID());
+		File file1 = getPlayerFile("baub", event.playerDirectory, "BaublesNO_" + BaublesIDHandler.get(event.entityPlayer).getID());
 		if (!file1.exists()) {
 			File filep = event.getPlayerFile("baub");
 			if (filep.exists()) {
@@ -80,7 +80,7 @@ public class EventHandlerEntity {
 			}
 		}
 		
-		PlayerHandler.loadPlayerBaubles(event.entityPlayer, file1, getPlayerFile("baubback", event.playerDirectory, "baublesNO" + BaublesIDHandler.get(event.entityPlayer).getID()));
+		PlayerHandler.loadPlayerBaubles(event.entityPlayer, file1, getPlayerFile("baubback", event.playerDirectory, "BaublesNO_" + BaublesIDHandler.get(event.entityPlayer).getID()));
 		EventHandlerNetwork.syncBaubles(event.entityPlayer);
 	}
 	
@@ -102,35 +102,35 @@ public class EventHandlerEntity {
 	@SubscribeEvent
 	public void playerSave(PlayerEvent.SaveToFile event) {
 		PlayerHandler.savePlayerBaubles(event.entityPlayer, 
-				getPlayerFile("baub", event.playerDirectory, "baublesNO" + BaublesIDHandler.get(event.entityPlayer).getID()),
-				getPlayerFile("baubback", event.playerDirectory, "baublesNO" + BaublesIDHandler.get(event.entityPlayer).getID()));
+				getPlayerFile("baub", event.playerDirectory, "BaublesNO_" + BaublesIDHandler.get(event.entityPlayer).getID()),
+				getPlayerFile("baubback", event.playerDirectory, "BaublesNO_" + BaublesIDHandler.get(event.entityPlayer).getID()));
 	}
 	
 	@SubscribeEvent
 	public void onPlayerConstruct(EntityConstructing event){
 		if(!event.entity.worldObj.isRemote && event.entity instanceof EntityPlayer && 
-				BaublesIDHandler.get((EntityPlayer) event.entity) == null){
+				BaublesIDHandler.get((EntityPlayer) event.entity) == null)
 			BaublesIDHandler.register((EntityPlayer) event.entity);
-			Config.addBaublesID();
-		}
 	}
 	
 	@SubscribeEvent
-	public void onLivingDeathEvent(LivingDeathEvent event){
+	public void onPlayerDeath(LivingDeathEvent event){
 		if (!event.entity.worldObj.isRemote && event.entity instanceof EntityPlayer){
 			NBTTagCompound baublesID = new NBTTagCompound();
-			((BaublesIDHandler)(event.entity.getExtendedProperties(BaublesIDHandler.EXT_PROP_NAME))).saveNBTData(baublesID);
+			BaublesIDHandler.get((EntityPlayer)event.entity).saveNBTData(baublesID);
 			Baubles.proxy.storeBaublesID(((EntityPlayer) event.entity).getDisplayNameString(), baublesID);
 			}
 	}
 
 	@SubscribeEvent
-	public void onEntityJoinWorld(EntityJoinWorldEvent event){
+	public void onPlayerJoinWorld(EntityJoinWorldEvent event){
 		if (!event.entity.worldObj.isRemote && event.entity instanceof EntityPlayer){
 			NBTTagCompound baublesID = Baubles.proxy.getBaublesID(((EntityPlayer) event.entity).getDisplayNameString());
 			if (baublesID != null){
-				((BaublesIDHandler)(event.entity.getExtendedProperties(BaublesIDHandler.EXT_PROP_NAME))).loadNBTData(baublesID);
+				BaublesIDHandler.get((EntityPlayer)event.entity).loadNBTData(baublesID);
 				}
+			else if (BaublesIDHandler.get((EntityPlayer)event.entity).getID() == Config.getNewBaublesID())
+				Config.addBaublesID();
 		}
 	}
 }

--- a/src/main/java/baubles/common/event/EventHandlerEntity.java
+++ b/src/main/java/baubles/common/event/EventHandlerEntity.java
@@ -108,7 +108,7 @@ public class EventHandlerEntity {
 	
 	@SubscribeEvent
 	public void onPlayerConstruct(EntityConstructing event){
-		if(event.entity instanceof EntityPlayer && 
+		if(!event.entity.worldObj.isRemote && event.entity instanceof EntityPlayer && 
 				BaublesIDHandler.get((EntityPlayer) event.entity) == null){
 			BaublesIDHandler.register((EntityPlayer) event.entity);
 			Config.addBaublesID();

--- a/src/main/java/baubles/common/lib/BaublesIDHandler.java
+++ b/src/main/java/baubles/common/lib/BaublesIDHandler.java
@@ -1,0 +1,61 @@
+package baubles.common.lib;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.World;
+import net.minecraftforge.common.IExtendedEntityProperties;
+import baubles.common.Baubles;
+import baubles.common.Config;
+
+public class BaublesIDHandler implements IExtendedEntityProperties{
+
+	public final static String EXT_PROP_NAME = "BaublesID";
+	private final EntityPlayer player;
+	private int baublesID;
+	
+	public BaublesIDHandler(EntityPlayer player){
+		this.player = player;
+		this.baublesID = Config.getNewBaublesID();
+	}
+	
+	public static final BaublesIDHandler get(EntityPlayer player){
+		return (BaublesIDHandler) player.getExtendedProperties(EXT_PROP_NAME);
+	}
+	
+	public static final void register(EntityPlayer player){
+		player.registerExtendedProperties(BaublesIDHandler.EXT_PROP_NAME, new BaublesIDHandler(player));
+	}
+	
+	
+	@Override
+	public void saveNBTData(NBTTagCompound compound) {
+		NBTTagCompound properties = new NBTTagCompound();
+		properties.setInteger("BaublesID", this.baublesID);
+		compound.setTag(EXT_PROP_NAME, properties);
+	}
+
+	@Override
+	public void loadNBTData(NBTTagCompound compound) {
+		NBTTagCompound properties = (NBTTagCompound) compound.getTag(EXT_PROP_NAME);
+		try
+		{
+			this.baublesID = properties.getInteger("BaublesID");
+		}
+		catch(Exception e)
+		{
+			Baubles.log.error("Could not load baubles inventory id, giving a new one.", e);
+			saveNBTData(compound);
+			loadNBTData(compound);
+			Config.addBaublesID();
+		}
+		
+	}
+
+	@Override
+	public void init(Entity entity, World world) {}
+
+	public int getID(){
+		return this.baublesID;
+	}
+}


### PR DESCRIPTION
Changed the way baubles are saved by binding a bauble inventory file to a player's save file, This fixes #90, fixes #89, while hopefully working around the Thaumcraft bug Azanor mentioned. Also fixed issues #92 and #86  by moving the rendering into the client proxy instead of calling it in init