### PR TITLE
Fix bauble button alignment when potion shift is disabled

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ processResources
         exclude 'mcmod.info'
     }
     
+    // Move access transformers to META-INF
+    rename '(.+_at.cfg)', 'META-INF/$1'
 }
 
 // Create deobf dev jars

--- a/src/main/java/baubles/client/gui/GuiBaublesButton.java
+++ b/src/main/java/baubles/client/gui/GuiBaublesButton.java
@@ -5,23 +5,23 @@ import org.lwjgl.opengl.GL11;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiButton;
+import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.renderer.GlStateManager;
-import net.minecraft.client.renderer.OpenGlHelper;
 
 public class GuiBaublesButton extends GuiButton {
 
-	public GuiBaublesButton(int buttonId, int x, int y, int width, int height, String buttonText) {
-		super(buttonId, x, y, width, height, buttonText);
+	private final int guiLeft;
+
+	public GuiBaublesButton(int buttonId, int guiLeft, int guiTop, int x, int y, int width, int height, String buttonText) {
+		super(buttonId, guiLeft + x, guiTop + y, width, height, buttonText);
+		this.guiLeft = guiLeft;
 	}
 	
 	
 	
 	@Override
 	public boolean mousePressed(Minecraft mc, int mouseX, int mouseY) {
-		int potionShift = 0;
-    	if (mc.thePlayer!=null && !mc.thePlayer.getActivePotionEffects().isEmpty()) {
-        	potionShift = 60;
-        }
+		int potionShift = getPotionShift(mc);
 		return super.mousePressed(mc, mouseX - potionShift, mouseY);
 	}
 
@@ -32,10 +32,7 @@ public class GuiBaublesButton extends GuiButton {
     {
         if (this.visible)
         {
-        	int potionShift = 0;
-        	if (mc.thePlayer!=null && !mc.thePlayer.getActivePotionEffects().isEmpty()) {
-	        	potionShift = 60;
-	        }
+        	int potionShift = getPotionShift(mc);
         	
             FontRenderer fontrenderer = mc.fontRendererObj;
             mc.getTextureManager().bindTexture(GuiPlayerExpanded.background);
@@ -62,4 +59,11 @@ public class GuiBaublesButton extends GuiButton {
         }
     }
 
+	private int getPotionShift(Minecraft mc) {
+		if (mc.currentScreen instanceof GuiContainer) {
+			GuiContainer guiContainer = (GuiContainer) mc.currentScreen;
+			return this.guiLeft - guiContainer.guiLeft;
+		}
+		return 0;
+	}
 }

--- a/src/main/java/baubles/client/gui/GuiEvents.java
+++ b/src/main/java/baubles/client/gui/GuiEvents.java
@@ -1,7 +1,6 @@
 package baubles.client.gui;
 
-import java.lang.reflect.Method;
-
+import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.gui.inventory.GuiInventory;
 import net.minecraft.client.resources.I18n;
 import net.minecraftforge.client.event.GuiScreenEvent;
@@ -19,14 +18,8 @@ public class GuiEvents {
 	public void guiPostInit(GuiScreenEvent.InitGuiEvent.Post event) {
 
 		if (event.getGui() instanceof GuiInventory || event.getGui() instanceof GuiPlayerExpanded) {
-			
-			int xSize = 176;
-		    int ySize = 166;
-			
-			int guiLeft = (event.getGui().width - xSize) / 2;
-	        int guiTop = (event.getGui().height - ySize) / 2;
-			
-			event.getButtonList().add(new GuiBaublesButton(55, guiLeft + 64, guiTop + 9, 10, 10, 
+			GuiContainer gui = (GuiContainer) event.getGui();
+			event.getButtonList().add(new GuiBaublesButton(55, gui.guiLeft, gui.guiTop, 64, 9, 10, 10,
 					I18n.format((event.getGui() instanceof GuiInventory)?"button.baubles":"button.normal", new Object[0])));
 		}
 		

--- a/src/main/resources/baubles_at.cfg
+++ b/src/main/resources/baubles_at.cfg
@@ -1,0 +1,5 @@
+#field access
+public net.minecraft.client.gui.inventory.GuiContainer field_146999_f #xSize
+public net.minecraft.client.gui.inventory.GuiContainer field_147000_g #ySize
+public net.minecraft.client.gui.inventory.GuiContainer field_147003_i #guiLeft
+public net.minecraft.client.gui.inventory.GuiContainer field_147009_r #guiTop


### PR DESCRIPTION
I added a new event in Forge for Minecraft 1.9 that allows mods to disable the potion-shift on guis. Currently, the Baubles button is misaligned when the potion-shift is canceled.

This PR lets Baubles get `guiLeft` directly using an access transformer, instead of guessing based on hard-coded values.