### PR TITLE
Remove access transformer for GuiContainer fields in 1.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,25 +41,12 @@ processResources
     from(sourceSets.main.resources.srcDirs) {
         exclude 'mcmod.info'
     }
-    
-    // Move access transformers to META-INF
-    rename '(.+_at.cfg)', 'META-INF/$1'
 }
-
-def commonManifest = {
-    attributes 'FMLAT': 'baubles_at.cfg'
-}
-
-jar {
-    manifest commonManifest
-}
-
 
 // Create deobf dev jars
 task deobfJar(type: Jar) {
     from sourceSets.main.output
     classifier = 'deobf'
-    manifest commonManifest    
 }
 
 // Create API library zip

--- a/src/main/java/baubles/client/gui/GuiBaublesButton.java
+++ b/src/main/java/baubles/client/gui/GuiBaublesButton.java
@@ -62,7 +62,7 @@ public class GuiBaublesButton extends GuiButton {
 	private int getPotionShift(Minecraft mc) {
 		if (mc.currentScreen instanceof GuiContainer) {
 			GuiContainer guiContainer = (GuiContainer) mc.currentScreen;
-			return guiContainer.guiLeft - this.guiLeft;
+			return guiContainer.getGuiLeft() - this.guiLeft;
 		}
 		return 0;
 	}

--- a/src/main/java/baubles/client/gui/GuiEvents.java
+++ b/src/main/java/baubles/client/gui/GuiEvents.java
@@ -19,7 +19,7 @@ public class GuiEvents {
 
 		if (event.getGui() instanceof GuiInventory || event.getGui() instanceof GuiPlayerExpanded) {
 			GuiContainer gui = (GuiContainer) event.getGui();
-			event.getButtonList().add(new GuiBaublesButton(55, gui.guiLeft, gui.guiTop, 64, 9, 10, 10,
+			event.getButtonList().add(new GuiBaublesButton(55, gui.getGuiLeft(), gui.getGuiTop(), 64, 9, 10, 10,
 					I18n.format((event.getGui() instanceof GuiInventory)?"button.baubles":"button.normal", new Object[0])));
 		}
 		

--- a/src/main/resources/baubles_at.cfg
+++ b/src/main/resources/baubles_at.cfg
@@ -1,5 +1,0 @@
-#field access
-public net.minecraft.client.gui.inventory.GuiContainer field_146999_f #xSize
-public net.minecraft.client.gui.inventory.GuiContainer field_147000_g #ySize
-public net.minecraft.client.gui.inventory.GuiContainer field_147003_i #guiLeft
-public net.minecraft.client.gui.inventory.GuiContainer field_147009_r #guiTop


### PR DESCRIPTION
In 1.11 I added getter methods in Forge for some fields in GuiContainer, so the access transformer in Baubles is no longer necessary.