### PR TITLE
Update the 1.10.2 branch to the correct mappings. Closes #182

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,9 +21,9 @@ srcCompat = JavaVersion.VERSION_1_8
 targetCompat = JavaVersion.VERSION_1_8
 
 minecraft {
-    version = "1.10.2-12.18.1.2084"
+    version = "1.10.2-12.18.3.2254"
     runDir = "run"
-    mappings = "snapshot_20160518"
+    mappings = "stable_29"
     makeObfSourceJar = false
 }
 

--- a/src/main/java/baubles/api/inv/BaublesInventoryWrapper.java
+++ b/src/main/java/baubles/api/inv/BaublesInventoryWrapper.java
@@ -75,7 +75,7 @@ public class BaublesInventoryWrapper implements IInventory {
 	public void markDirty() {	}
 
 	@Override
-	public boolean isUseableByPlayer(EntityPlayer player) {
+	public boolean isUsableByPlayer(EntityPlayer player) {
 		return true;
 	}
 

--- a/src/main/java/baubles/client/ClientProxy.java
+++ b/src/main/java/baubles/client/ClientProxy.java
@@ -41,7 +41,7 @@ public class ClientProxy extends CommonProxy {
 				
 	@Override
 	public World getClientWorld() {
-		return FMLClientHandler.instance().getClient().theWorld;
+		return FMLClientHandler.instance().getClient().world;
 	}
 	
 	@Override

--- a/src/main/java/baubles/client/gui/GuiEvents.java
+++ b/src/main/java/baubles/client/gui/GuiEvents.java
@@ -31,14 +31,14 @@ public class GuiEvents {
 
 		if (event.getGui() instanceof GuiInventory) {
 			if (event.getButton().id == 55) {
-				PacketHandler.INSTANCE.sendToServer(new PacketOpenBaublesInventory(event.getGui().mc.thePlayer));
+				PacketHandler.INSTANCE.sendToServer(new PacketOpenBaublesInventory(event.getGui().mc.player));
 			}
 		}
 		
 		if (event.getGui() instanceof GuiPlayerExpanded) {
 			if (event.getButton().id == 55) {
-				event.getGui().mc.displayGuiScreen(new GuiInventory(event.getGui().mc.thePlayer));
-				PacketHandler.INSTANCE.sendToServer(new PacketOpenNormalInventory(event.getGui().mc.thePlayer));
+				event.getGui().mc.displayGuiScreen(new GuiInventory(event.getGui().mc.player));
+				PacketHandler.INSTANCE.sendToServer(new PacketOpenNormalInventory(event.getGui().mc.player));
 			}
 		}
 	}

--- a/src/main/java/baubles/client/gui/GuiPlayerExpanded.java
+++ b/src/main/java/baubles/client/gui/GuiPlayerExpanded.java
@@ -35,7 +35,7 @@ public class GuiPlayerExpanded extends InventoryEffectRenderer {
 
     public GuiPlayerExpanded(EntityPlayer player)
     {
-        super(new ContainerPlayerExpanded(player.inventory, !player.worldObj.isRemote, player));
+        super(new ContainerPlayerExpanded(player.inventory, !player.world.isRemote, player));
         this.allowUserInput = true;
     }
 
@@ -96,11 +96,11 @@ public class GuiPlayerExpanded extends InventoryEffectRenderer {
             Slot slot = (Slot)this.inventorySlots.inventorySlots.get(i1);
             if (slot.getHasStack() && slot.getSlotStackLimit()==1)
             {
-            	this.drawTexturedModalRect(k+slot.xDisplayPosition, l+slot.yDisplayPosition, 200, 0, 16, 16);
+            	this.drawTexturedModalRect(k+slot.xPos, l+slot.yPos, 200, 0, 16, 16);
             }
         }
         
-        drawPlayerModel(k + 51, l + 75, 30, (float)(k + 51) - this.xSizeFloat, (float)(l + 75 - 50) - this.ySizeFloat, this.mc.thePlayer);
+        drawPlayerModel(k + 51, l + 75, 30, (float)(k + 51) - this.xSizeFloat, (float)(l + 75 - 50) - this.ySizeFloat, this.mc.player);
     }
 
     public static void drawPlayerModel(int x, int y, int scale, float yaw, float pitch, EntityLivingBase playerdrawn)
@@ -149,12 +149,12 @@ public class GuiPlayerExpanded extends InventoryEffectRenderer {
     {
         if (button.id == 0)
         {
-            this.mc.displayGuiScreen(new GuiAchievements(this, this.mc.thePlayer.getStatFileWriter()));
+            this.mc.displayGuiScreen(new GuiAchievements(this, this.mc.player.getStatFileWriter()));
         }
 
         if (button.id == 1)
         {
-            this.mc.displayGuiScreen(new GuiStats(this, this.mc.thePlayer.getStatFileWriter()));
+            this.mc.displayGuiScreen(new GuiStats(this, this.mc.player.getStatFileWriter()));
         }
     }
 
@@ -162,7 +162,7 @@ public class GuiPlayerExpanded extends InventoryEffectRenderer {
 	protected void keyTyped(char par1, int par2) throws IOException {
 		if (par2 == Baubles.proxy.keyHandler.key.getKeyCode())
         {
-            this.mc.thePlayer.closeScreen();
+            this.mc.player.closeScreen();
         } else
 		super.keyTyped(par1, par2);
 	}

--- a/src/main/java/baubles/common/container/ContainerPlayerExpanded.java
+++ b/src/main/java/baubles/common/container/ContainerPlayerExpanded.java
@@ -130,7 +130,7 @@ public class ContainerPlayerExpanded extends Container
     @Override
     public void onCraftMatrixChanged(IInventory par1IInventory)
     {
-        this.craftResult.setInventorySlotContents(0, CraftingManager.getInstance().findMatchingRecipe(this.craftMatrix, this.thePlayer.worldObj));
+        this.craftResult.setInventorySlotContents(0, CraftingManager.getInstance().findMatchingRecipe(this.craftMatrix, this.thePlayer.world));
     }
 
     /**

--- a/src/main/java/baubles/common/event/CommandBaubles.java
+++ b/src/main/java/baubles/common/event/CommandBaubles.java
@@ -23,22 +23,23 @@ public class CommandBaubles extends CommandBase {
 		this.aliases.add("baub");
 		this.aliases.add("bau");
 	}	
-		
+
 	@Override
-	public String getCommandName() {
+	public String getName() {
+		
 		return "baubles";
 	}
 	
 	@Override
-	public List<String> getCommandAliases() {
+	public List<String> getAliases() {
 		return aliases;
     }
 
 	@Override
-	public String getCommandUsage(ICommandSender icommandsender) {
+	public String getUsage(ICommandSender sender) {
 		return "/baubles <action> [<player> [<params>]]";
 	}
-
+	
 	@Override
 	public int getRequiredPermissionLevel() {
 		return 2;
@@ -52,30 +53,30 @@ public class CommandBaubles extends CommandBase {
 	@Override
 	public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
 		if (args.length < 2 || args[0].equalsIgnoreCase("help")) {
-			sender.addChatMessage(new TextComponentTranslation("\u00a73You can also use /baub or /bau instead of /baubles."));
-			sender.addChatMessage(new TextComponentTranslation("\u00a73Use this to view the baubles inventory of a player."));
-			sender.addChatMessage(new TextComponentTranslation("  /baubles view <player>"));
-			sender.addChatMessage(new TextComponentTranslation("\u00a73Use this to clear a players baubles inventory. Default is everything or you can give a slot number"));
-			sender.addChatMessage(new TextComponentTranslation("  /baubles clear <player> [<slot>]"));
+			sender.sendMessage(new TextComponentTranslation("\u00a73You can also use /baub or /bau instead of /baubles."));
+			sender.sendMessage(new TextComponentTranslation("\u00a73Use this to view the baubles inventory of a player."));
+			sender.sendMessage(new TextComponentTranslation("  /baubles view <player>"));
+			sender.sendMessage(new TextComponentTranslation("\u00a73Use this to clear a players baubles inventory. Default is everything or you can give a slot number"));
+			sender.sendMessage(new TextComponentTranslation("  /baubles clear <player> [<slot>]"));
 		} else 
 		if (args.length >= 2) {
 			EntityPlayerMP entityplayermp = getPlayer(server,sender,args[1]);
 			
 			if (entityplayermp==null) {
-				sender.addChatMessage(new TextComponentTranslation("\u00a7c"+args[1]+" not found"));
+				sender.sendMessage(new TextComponentTranslation("\u00a7c"+args[1]+" not found"));
 				return;
 			}
 			
 			IBaublesItemHandler baubles = BaublesApi.getBaublesHandler(entityplayermp);
 			
 			if (args[0].equalsIgnoreCase("view")) {				
-				sender.addChatMessage(new TextComponentTranslation("\u00a73Showing baubles for "+entityplayermp.getName()));
+				sender.sendMessage(new TextComponentTranslation("\u00a73Showing baubles for "+entityplayermp.getName()));
 				for (int a = 0; a<baubles.getSlots();a++) {
 					ItemStack st = baubles.getStackInSlot(a);
 					if (st!=null && st.getItem() instanceof IBauble) {
 						IBauble bauble=(IBauble)st.getItem();
 						BaubleType bt = bauble.getBaubleType(st);
-						sender.addChatMessage(new TextComponentTranslation("\u00a73 [Slot "+a+"] "+bt+" "+st.getDisplayName()));
+						sender.sendMessage(new TextComponentTranslation("\u00a73 [Slot "+a+"] "+bt+" "+st.getDisplayName()));
 					}
 				}
 			} else 
@@ -84,28 +85,28 @@ public class CommandBaubles extends CommandBase {
 					int slot = -1;
 					try { slot = Integer.parseInt(args[2]); } catch (Exception e) {}
 					if (slot<0 || slot >= baubles.getSlots()) {
-						sender.addChatMessage(new TextComponentTranslation("\u00a7cInvalid arguments"));
-						sender.addChatMessage(new TextComponentTranslation("\u00a7cUse /baubles help to get help"));
+						sender.sendMessage(new TextComponentTranslation("\u00a7cInvalid arguments"));
+						sender.sendMessage(new TextComponentTranslation("\u00a7cUse /baubles help to get help"));
 					} else {
 						baubles.setStackInSlot(slot, null);
-						sender.addChatMessage(new TextComponentTranslation("\u00a73Cleared baubles slot "+slot+" for "+entityplayermp.getName()));
-						entityplayermp.addChatMessage(new TextComponentTranslation("\u00a74Your baubles slot "+slot+" has been cleared by admin "+sender.getName()));
+						sender.sendMessage(new TextComponentTranslation("\u00a73Cleared baubles slot "+slot+" for "+entityplayermp.getName()));
+						entityplayermp.sendMessage(new TextComponentTranslation("\u00a74Your baubles slot "+slot+" has been cleared by admin "+sender.getName()));
 					}
 				} else {
 					for (int a = 0; a<baubles.getSlots();a++) {
 						baubles.setStackInSlot(a, null);						
 					}
-					sender.addChatMessage(new TextComponentTranslation("\u00a73Cleared all baubles slots for "+entityplayermp.getName()));
-					entityplayermp.addChatMessage(new TextComponentTranslation("\u00a74All your baubles slots have been cleared by admin "+sender.getName()));					
+					sender.sendMessage(new TextComponentTranslation("\u00a73Cleared all baubles slots for "+entityplayermp.getName()));
+					entityplayermp.sendMessage(new TextComponentTranslation("\u00a74All your baubles slots have been cleared by admin "+sender.getName()));					
 				}				
 			} else {
-				sender.addChatMessage(new TextComponentTranslation("\u00a7cInvalid arguments"));
-				sender.addChatMessage(new TextComponentTranslation("\u00a7cUse /baubles help to get help"));
+				sender.sendMessage(new TextComponentTranslation("\u00a7cInvalid arguments"));
+				sender.sendMessage(new TextComponentTranslation("\u00a7cUse /baubles help to get help"));
 			}
 
 		} else {
-			sender.addChatMessage(new TextComponentTranslation("\u00a7cInvalid arguments"));
-			sender.addChatMessage(new TextComponentTranslation("\u00a7cUse /baubles help to get help"));
+			sender.sendMessage(new TextComponentTranslation("\u00a7cInvalid arguments"));
+			sender.sendMessage(new TextComponentTranslation("\u00a7cUse /baubles help to get help"));
 		}
 
 	}

--- a/src/main/java/baubles/common/event/EventHandlerEntity.java
+++ b/src/main/java/baubles/common/event/EventHandlerEntity.java
@@ -15,6 +15,7 @@ import baubles.api.cap.IBaublesItemHandler;
 import baubles.common.Baubles;
 import baubles.common.network.PacketHandler;
 import baubles.common.network.PacketSync;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
@@ -25,7 +26,6 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.text.TextFormatting;
-import net.minecraft.util.text.translation.I18n;
 import net.minecraftforge.event.AttachCapabilitiesEvent;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
@@ -128,8 +128,8 @@ public class EventHandlerEntity {
 	@SubscribeEvent
 	public void playerDeath(PlayerDropsEvent event) {
 		if (event.getEntity() instanceof EntityPlayer
-				&& !event.getEntity().worldObj.isRemote
-				&& !event.getEntity().worldObj.getGameRules().getBoolean("keepInventory")) {			
+				&& !event.getEntity().world.isRemote
+				&& !event.getEntity().world.getGameRules().getBoolean("keepInventory")) {			
 			dropItemsAt(event.getEntityPlayer(),event.getDrops(),event.getEntityPlayer());						
 		}
 	}
@@ -138,12 +138,12 @@ public class EventHandlerEntity {
 		IBaublesItemHandler baubles = BaublesApi.getBaublesHandler(player);
 		for (int i = 0; i < baubles.getSlots(); ++i) {
 			if (baubles.getStackInSlot(i) != null) {
-				EntityItem ei = new EntityItem(e.worldObj,
+				EntityItem ei = new EntityItem(e.world,
 						e.posX, e.posY + e.getEyeHeight(), e.posZ,
 						baubles.getStackInSlot(i).copy());
 				ei.setPickupDelay(40);
-				float f1 = e.worldObj.rand.nextFloat() * 0.5F;
-				float f2 = e.worldObj.rand.nextFloat() * (float) Math.PI * 2.0F;
+				float f1 = e.world.rand.nextFloat() * 0.5F;
+				float f2 = e.world.rand.nextFloat() * (float) Math.PI * 2.0F;
 				ei.motionX = (double) (-MathHelper.sin(f2) * f1);
 				ei.motionZ = (double) (MathHelper.cos(f2) * f1);
 				ei.motionY = 0.20000000298023224D;
@@ -158,7 +158,7 @@ public class EventHandlerEntity {
 	public void tooltipEvent(ItemTooltipEvent event) {
 		if (event.getItemStack()!=null && event.getItemStack().getItem() instanceof IBauble) {
 			BaubleType bt = ((IBauble)event.getItemStack().getItem()).getBaubleType(event.getItemStack());
-			event.getToolTip().add(TextFormatting.GOLD+I18n.translateToLocal("name."+bt));
+			event.getToolTip().add(TextFormatting.GOLD+I18n.format("name."+bt));
 		}
 	}
 	
@@ -175,7 +175,7 @@ public class EventHandlerEntity {
 	}
 	
 	public void loadPlayerBaubles(EntityPlayer player, File file1, File file2) {
-		if (player != null && !player.worldObj.isRemote) {
+		if (player != null && !player.world.isRemote) {
 			try {
 				NBTTagCompound data = null;
 				boolean save = false;

--- a/src/main/java/baubles/common/network/PacketOpenBaublesInventory.java
+++ b/src/main/java/baubles/common/network/PacketOpenBaublesInventory.java
@@ -23,9 +23,9 @@ public class PacketOpenBaublesInventory implements IMessage, IMessageHandler<Pac
 
 	@Override
 	public IMessage onMessage(PacketOpenBaublesInventory message, MessageContext ctx) {
-		IThreadListener mainThread = (WorldServer) ctx.getServerHandler().playerEntity.worldObj; 
+		IThreadListener mainThread = (WorldServer) ctx.getServerHandler().playerEntity.world; 
         mainThread.addScheduledTask(new Runnable(){ public void run() { 		
-			ctx.getServerHandler().playerEntity.openGui(Baubles.instance, Baubles.GUI, ctx.getServerHandler().playerEntity.worldObj, (int)ctx.getServerHandler().playerEntity.posX, (int)ctx.getServerHandler().playerEntity.posY, (int)ctx.getServerHandler().playerEntity.posZ);
+			ctx.getServerHandler().playerEntity.openGui(Baubles.instance, Baubles.GUI, ctx.getServerHandler().playerEntity.world, (int)ctx.getServerHandler().playerEntity.posX, (int)ctx.getServerHandler().playerEntity.posY, (int)ctx.getServerHandler().playerEntity.posZ);
 		}});
 		return null;
 	}

--- a/src/main/java/baubles/common/network/PacketOpenNormalInventory.java
+++ b/src/main/java/baubles/common/network/PacketOpenNormalInventory.java
@@ -22,7 +22,7 @@ public class PacketOpenNormalInventory implements IMessage, IMessageHandler<Pack
 
 	@Override
 	public IMessage onMessage(PacketOpenNormalInventory message, MessageContext ctx) {
-		IThreadListener mainThread = (WorldServer) ctx.getServerHandler().playerEntity.worldObj; 
+		IThreadListener mainThread = (WorldServer) ctx.getServerHandler().playerEntity.world; 
         mainThread.addScheduledTask(new Runnable(){ public void run() { 			
 			ctx.getServerHandler().playerEntity.openContainer.onContainerClosed(ctx.getServerHandler().playerEntity);		
 			ctx.getServerHandler().playerEntity.openContainer = ctx.getServerHandler().playerEntity.inventoryContainer;


### PR DESCRIPTION
The 1.10.2 branch of Baubles was using an older version of forge, and MCP mappings which were intended for MC 1.9. This PR updates the mappings and fixes all the mapping issues associated with it. Due to the way baubles is set up, this causes issues such as #182 in the dev environment. 

**FOR OTHER DEVS**
If you're like me and need this fix sooner rather than later, my changes are available on JitPack. Given how my changes don't change any method signatures outside of those obfuscated for vanilla, it should be completely safe to use my fork for testing and building. 

```
        repositories {
            maven {
                url 'https://jitpack.io'
            }
        }
        dependencies {
            deobfCompile 'com.github.Darkhax-Forked:Baubles:1.10.2-SNAPSHOT'
        }
```