### PR TITLE
fixed modid casing in mcmod.info

### DIFF
--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -1,6 +1,6 @@
 [
 {
-  "modid": "Baubles",
+  "modid": "baubles",
   "name": "Baubles",
   "description": "Adding a touch of bling to Minecraft",
   "version": "${version}",


### PR DESCRIPTION
The modid still had the uppercase B, small oversight on my last PR.
Fixes #206 

> The 1.10.2 version does not need this change, since the modid is still uppercase in that branch.