### PR TITLE
Feature/bauble capability

### DIFF
--- a/src/main/java/baubles/api/cap/BaubleItem.java
+++ b/src/main/java/baubles/api/cap/BaubleItem.java
@@ -2,7 +2,6 @@ package baubles.api.cap;
 
 import baubles.api.BaubleType;
 import baubles.api.IBauble;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
 public class BaubleItem implements IBauble
@@ -16,17 +15,5 @@ public class BaubleItem implements IBauble
 	@Override
 	public BaubleType getBaubleType(ItemStack itemstack) {
 		return baubleType;
-	}
-
-	@Override
-	public void onWornTick(ItemStack itemstack, EntityLivingBase player) {
-	}
-
-	@Override
-	public void onEquipped(ItemStack itemstack, EntityLivingBase player) {
-	}
-
-	@Override
-	public void onUnequipped(ItemStack itemstack, EntityLivingBase player) {
 	}
 }

--- a/src/main/java/baubles/api/cap/BaubleItem.java
+++ b/src/main/java/baubles/api/cap/BaubleItem.java
@@ -1,0 +1,32 @@
+package baubles.api.cap;
+
+import baubles.api.BaubleType;
+import baubles.api.IBauble;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.ItemStack;
+
+public class BaubleItem implements IBauble
+{
+	private BaubleType baubleType;
+
+	public BaubleItem(BaubleType type) {
+		baubleType = type;
+	}
+
+	@Override
+	public BaubleType getBaubleType(ItemStack itemstack) {
+		return baubleType;
+	}
+
+	@Override
+	public void onWornTick(ItemStack itemstack, EntityLivingBase player) {
+	}
+
+	@Override
+	public void onEquipped(ItemStack itemstack, EntityLivingBase player) {
+	}
+
+	@Override
+	public void onUnequipped(ItemStack itemstack, EntityLivingBase player) {
+	}
+}

--- a/src/main/java/baubles/api/cap/BaublesCapabilities.java
+++ b/src/main/java/baubles/api/cap/BaublesCapabilities.java
@@ -1,10 +1,13 @@
 package baubles.api.cap;
 
+import baubles.api.IBauble;
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.Capability.IStorage;
 import net.minecraftforge.common.capabilities.CapabilityInject;
+
+import javax.annotation.Nonnull;
 
 public class BaublesCapabilities {
 	
@@ -13,6 +16,9 @@ public class BaublesCapabilities {
      */
     @CapabilityInject(IBaublesItemHandler.class)
     public static final Capability<IBaublesItemHandler> CAPABILITY_BAUBLES = null;
+
+    @CapabilityInject(IBauble.class)
+    public static final Capability<IBauble> CAPABILITY_ITEM_BAUBLE = null;
     
     public static class CapabilityBaubles<T extends IBaublesItemHandler> implements IStorage<IBaublesItemHandler> {
         
@@ -27,5 +33,19 @@ public class BaublesCapabilities {
         
         }
     }
-    
+
+    public static class CapabilityItemBaubleStorage implements IStorage<IBauble> {
+
+        @Override
+        public NBTBase writeNBT (Capability<IBauble> capability, IBauble instance, EnumFacing side) {
+
+            return null;
+        }
+
+        @Override
+        public void readNBT (Capability<IBauble> capability, IBauble instance, EnumFacing side, NBTBase nbt) {
+
+        }
+    }
+
 }

--- a/src/main/java/baubles/api/cap/BaublesContainer.java
+++ b/src/main/java/baubles/api/cap/BaublesContainer.java
@@ -36,10 +36,10 @@ public class BaublesContainer extends ItemStackHandler implements IBaublesItemHa
 	 */
 	@Override
 	public boolean isItemValidForSlot(int slot, ItemStack stack, EntityLivingBase player) {
-		if (stack==null || stack.isEmpty() || !(stack.getItem() instanceof IBauble) ||
-				!((IBauble) stack.getItem()).canEquip(stack, player))
-			return false;		
-		return ((IBauble) stack.getItem()).getBaubleType(stack).hasSlot(slot);
+		if (stack==null || stack.isEmpty() || !stack.hasCapability(BaublesCapabilities.CAPABILITY_ITEM_BAUBLE, null))
+			return false;
+		IBauble bauble = stack.getCapability(BaublesCapabilities.CAPABILITY_ITEM_BAUBLE, null);
+		return bauble.canEquip(stack, player) && bauble.getBaubleType(stack).hasSlot(slot);
 	}
 	
 	@Override

--- a/src/main/java/baubles/common/Baubles.java
+++ b/src/main/java/baubles/common/Baubles.java
@@ -2,6 +2,13 @@ package baubles.common;
 
 import java.io.File;
 
+import baubles.api.BaubleType;
+import baubles.api.IBauble;
+import baubles.api.cap.BaubleItem;
+import baubles.api.cap.BaublesCapabilities;
+import baubles.common.event.EventHandlerItem;
+import net.minecraft.client.Minecraft;
+import net.minecraftforge.client.MinecraftForgeClient;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -41,6 +48,7 @@ public class Baubles {
 	public static Baubles instance;
 	
 	public EventHandlerEntity entityEventHandler;
+	public EventHandlerItem itemEventHandler;
 	public File modDir;
 	
 	public static final Logger log = LogManager.getLogger(MODID.toUpperCase());
@@ -60,12 +68,18 @@ public class Baubles {
 				
 		CapabilityManager.INSTANCE.register(IBaublesItemHandler.class, 
 				new CapabilityBaubles<IBaublesItemHandler>(), BaublesContainer.class);
+
+		CapabilityManager.INSTANCE.register(IBauble.class,
+				new BaublesCapabilities.CapabilityItemBaubleStorage(), () -> new BaubleItem(BaubleType.TRINKET));
 						
 		PacketHandler.init();
 		
 		entityEventHandler = new EventHandlerEntity();
-		
+		itemEventHandler = new EventHandlerItem();
+
 		MinecraftForge.EVENT_BUS.register(entityEventHandler);
+		MinecraftForge.EVENT_BUS.register(itemEventHandler);
+
 
 		/////////////////////
 		proxy.registerItemModels();

--- a/src/main/java/baubles/common/container/ContainerPlayerExpanded.java
+++ b/src/main/java/baubles/common/container/ContainerPlayerExpanded.java
@@ -231,17 +231,17 @@ public class ContainerPlayerExpanded extends Container
             }
             
             // inv -> bauble
-            else if (itemstack.getItem() instanceof IBauble)
+            else if (itemstack.hasCapability(BaublesCapabilities.CAPABILITY_ITEM_BAUBLE, null))
             {
-            	IBauble bauble = (IBauble) itemstack1.getItem();            	
-            	for (int baubleSlot : bauble.getBaubleType(itemstack).getValidSlots()) {				
-	                if ( bauble.canEquip(itemstack1, thePlayer) && !((Slot)this.inventorySlots.get(baubleSlot+9)).getHasStack() &&	                		
-	                		!this.mergeItemStack(itemstack1, baubleSlot+9, baubleSlot + 10, false))
-	                {
-	                    return ItemStack.EMPTY;
-	                } 
-	                if (itemstack1.getCount() == 0) break;
-            	}
+            	IBauble bauble = itemstack.getCapability(BaublesCapabilities.CAPABILITY_ITEM_BAUBLE, null);
+                for (int baubleSlot : bauble.getBaubleType(itemstack).getValidSlots()) {
+                    if ( bauble.canEquip(itemstack1, thePlayer) && !((Slot)this.inventorySlots.get(baubleSlot+9)).getHasStack() &&
+                            !this.mergeItemStack(itemstack1, baubleSlot+9, baubleSlot + 10, false))
+                    {
+                        return ItemStack.EMPTY;
+                    }
+                    if (itemstack1.getCount() == 0) break;
+                }
             }            
             
             else if (index >= 9+ slotShift && index < 36+ slotShift)
@@ -293,7 +293,6 @@ public class ContainerPlayerExpanded extends Container
     private void unequipBauble(ItemStack stack) {
     	
     }
-    
 
     @Override
     public boolean canMergeSlot(ItemStack stack, Slot slot)

--- a/src/main/java/baubles/common/container/SlotBauble.java
+++ b/src/main/java/baubles/common/container/SlotBauble.java
@@ -31,12 +31,12 @@ public class SlotBauble extends SlotItemHandler
 
 	@Override
 	public boolean canTakeStack(EntityPlayer player) {
-    	ItemStack stack = getStack();
-    	if(stack==null || stack.isEmpty())
-    		return false;
+		ItemStack stack = getStack();
+		if(stack==null || stack.isEmpty())
+		    return false;
 
-    	IBauble bauble = stack.getCapability(BaublesCapabilities.CAPABILITY_ITEM_BAUBLE, null);
-    	// xalcon: the player should be able to unequip non-bauble items. Non-baubles shouldnt show up here, but we never know
+		IBauble bauble = stack.getCapability(BaublesCapabilities.CAPABILITY_ITEM_BAUBLE, null);
+		// xalcon: the player should be able to unequip non-bauble items. Non-baubles shouldnt show up here, but we never know
 		return bauble == null || bauble.canUnequip(stack, player);
 	}
 

--- a/src/main/java/baubles/common/container/SlotBauble.java
+++ b/src/main/java/baubles/common/container/SlotBauble.java
@@ -1,6 +1,7 @@
 package baubles.common.container;
 
 import baubles.api.IBauble;
+import baubles.api.cap.BaublesCapabilities;
 import baubles.api.cap.IBaublesItemHandler;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -30,15 +31,21 @@ public class SlotBauble extends SlotItemHandler
 
 	@Override
 	public boolean canTakeStack(EntityPlayer player) {
-		return getStack()!=null && !getStack().isEmpty() &&
-			   ((IBauble)getStack().getItem()).canUnequip(getStack(), player);
+    	ItemStack stack = getStack();
+    	if(stack==null || stack.isEmpty())
+    		return false;
+
+    	IBauble bauble = stack.getCapability(BaublesCapabilities.CAPABILITY_ITEM_BAUBLE, null);
+    	// xalcon: the player should be able to unequip non-bauble items. Non-baubles shouldnt show up here, but we never know
+		return bauble == null || bauble.canUnequip(stack, player);
 	}
 
 	@Override
 	public ItemStack onTake(EntityPlayer playerIn, ItemStack stack) {
+
 		if (!getHasStack() && !((IBaublesItemHandler)getItemHandler()).isEventBlocked() &&
-			stack.getItem() instanceof IBauble) {
-			((IBauble)stack.getItem()).onUnequipped(stack, playerIn);
+				stack.hasCapability(BaublesCapabilities.CAPABILITY_ITEM_BAUBLE, null)) {
+			stack.getCapability(BaublesCapabilities.CAPABILITY_ITEM_BAUBLE, null).onUnequipped(stack, playerIn);
 		}
 		super.onTake(playerIn, stack);
 		return stack;
@@ -46,14 +53,16 @@ public class SlotBauble extends SlotItemHandler
 
 	@Override
 	public void putStack(ItemStack stack) {
-		if (getHasStack() && !((IBaublesItemHandler)getItemHandler()).isEventBlocked()) {
-			((IBauble)getStack().getItem()).onUnequipped(getStack(), player);
+		if (getHasStack() && !((IBaublesItemHandler)getItemHandler()).isEventBlocked() &&
+				getStack().hasCapability(BaublesCapabilities.CAPABILITY_ITEM_BAUBLE, null)) {
+			getStack().getCapability(BaublesCapabilities.CAPABILITY_ITEM_BAUBLE, null).onUnequipped(getStack(), player);
 		}
 
 		super.putStack(stack);
 
-		if (this.getHasStack() && !((IBaublesItemHandler)getItemHandler()).isEventBlocked()) {
-			((IBauble)getStack().getItem()).onEquipped(getStack(), player);
+		if (this.getHasStack() && !((IBaublesItemHandler)getItemHandler()).isEventBlocked() &&
+				getStack().hasCapability(BaublesCapabilities.CAPABILITY_ITEM_BAUBLE, null)) {
+			getStack().getCapability(BaublesCapabilities.CAPABILITY_ITEM_BAUBLE, null).onEquipped(getStack(), player);
 		}
 	}
 

--- a/src/main/java/baubles/common/event/CommandBaubles.java
+++ b/src/main/java/baubles/common/event/CommandBaubles.java
@@ -6,6 +6,7 @@ import java.util.List;
 import baubles.api.BaubleType;
 import baubles.api.BaublesApi;
 import baubles.api.IBauble;
+import baubles.api.cap.BaublesCapabilities;
 import baubles.api.cap.IBaublesItemHandler;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandException;
@@ -72,8 +73,8 @@ public class CommandBaubles extends CommandBase {
 				sender.sendMessage(new TextComponentTranslation("\u00a73Showing baubles for "+entityplayermp.getName()));
 				for (int a = 0; a<baubles.getSlots();a++) {
 					ItemStack st = baubles.getStackInSlot(a);
-					if (st!=null && !st.isEmpty() && st.getItem() instanceof IBauble) {
-						IBauble bauble=(IBauble)st.getItem();
+					if (st!=null && !st.isEmpty() && st.hasCapability(BaublesCapabilities.CAPABILITY_ITEM_BAUBLE, null)) {
+						IBauble bauble = st.getCapability(BaublesCapabilities.CAPABILITY_ITEM_BAUBLE, null);
 						BaubleType bt = bauble.getBaubleType(st);
 						sender.sendMessage(new TextComponentTranslation("\u00a73 [Slot "+a+"] "+bt+" "+st.getDisplayName()));
 					}

--- a/src/main/java/baubles/common/event/EventHandlerEntity.java
+++ b/src/main/java/baubles/common/event/EventHandlerEntity.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import baubles.api.BaubleType;
 import baubles.api.BaublesApi;
 import baubles.api.IBauble;
+import baubles.api.cap.BaublesCapabilities;
 import baubles.api.cap.BaublesContainer;
 import baubles.api.cap.BaublesContainerProvider;
 import baubles.api.cap.IBaublesItemHandler;
@@ -108,8 +109,9 @@ public class EventHandlerEntity {
 			for (int a = 0; a < count; a++) {
 				ItemStack baubleStack = baubles.getStackInSlot(a);
 				IBauble bauble = null;
-				if (baubleStack != null && !baubleStack.isEmpty() && baubleStack.getItem() instanceof IBauble) {
-					bauble = (IBauble) baubleStack.getItem();
+				if (baubleStack != null && !baubleStack.isEmpty() && baubleStack.hasCapability(BaublesCapabilities.CAPABILITY_ITEM_BAUBLE, null)) {
+
+					bauble = baubleStack.getCapability(BaublesCapabilities.CAPABILITY_ITEM_BAUBLE, null);
 					//Worn Tick
 					bauble.onWornTick(baubleStack, player);
 				}				
@@ -157,8 +159,9 @@ public class EventHandlerEntity {
 	
 	@SubscribeEvent
 	public void tooltipEvent(ItemTooltipEvent event) {
-		if (event.getItemStack()!=null && !event.getItemStack().isEmpty() && event.getItemStack().getItem() instanceof IBauble) {
-			BaubleType bt = ((IBauble)event.getItemStack().getItem()).getBaubleType(event.getItemStack());
+		if (event.getItemStack()!=null && !event.getItemStack().isEmpty() && event.getItemStack().hasCapability(BaublesCapabilities.CAPABILITY_ITEM_BAUBLE, null)) {
+			IBauble bauble = event.getItemStack().getCapability(BaublesCapabilities.CAPABILITY_ITEM_BAUBLE, null);
+			BaubleType bt = bauble.getBaubleType(event.getItemStack());
 			event.getToolTip().add(TextFormatting.GOLD+I18n.translateToLocal("name."+bt));
 		}
 	}

--- a/src/main/java/baubles/common/event/EventHandlerItem.java
+++ b/src/main/java/baubles/common/event/EventHandlerItem.java
@@ -1,0 +1,54 @@
+package baubles.common.event;
+
+import baubles.api.IBauble;
+import baubles.api.cap.BaublesCapabilities;
+import baubles.common.Baubles;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.event.AttachCapabilitiesEvent;
+import net.minecraftforge.fml.common.eventhandler.EventPriority;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class EventHandlerItem
+{
+	private static ResourceLocation capabilityResourceLocation = new ResourceLocation(Baubles.MODID, "bauble_cap");
+
+	/**
+	 * Handles backwards compatibility with items that implement IBauble instead of exposing it as a capability.
+	 * This adds a IBauble capability wrapper for all items, if the item:
+	 * - does implement the IBauble interface
+	 * - does not already have the capability
+	 * - did not get the capability by another event handler earlier in the chain
+	 * @param event
+	 */
+	@SubscribeEvent(priority = EventPriority.LOWEST)
+	public void itemCapabilityAttach(AttachCapabilitiesEvent.Item event)
+	{
+		ItemStack stack = event.getItemStack();
+		if(stack.isEmpty() || !(stack.getItem() instanceof IBauble) || stack.hasCapability(BaublesCapabilities.CAPABILITY_ITEM_BAUBLE, null)
+				|| event.getCapabilities().values().stream().anyMatch(c -> c.hasCapability(BaublesCapabilities.CAPABILITY_ITEM_BAUBLE, null)))
+			return;
+
+		event.addCapability(capabilityResourceLocation, new ICapabilityProvider() {
+
+			@Override
+			public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing facing)
+			{
+				return capability == BaublesCapabilities.CAPABILITY_ITEM_BAUBLE;
+			}
+
+			@Nullable
+			@Override
+			public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing facing)
+			{
+				return capability == BaublesCapabilities.CAPABILITY_ITEM_BAUBLE ? (T)stack.getItem() : null;
+			}
+		});
+	}
+}

--- a/src/main/java/baubles/common/event/EventHandlerItem.java
+++ b/src/main/java/baubles/common/event/EventHandlerItem.java
@@ -47,7 +47,9 @@ public class EventHandlerItem
 			@Override
 			public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing facing)
 			{
-				return capability == BaublesCapabilities.CAPABILITY_ITEM_BAUBLE ? (T)stack.getItem() : null;
+				return capability == BaublesCapabilities.CAPABILITY_ITEM_BAUBLE
+						? BaublesCapabilities.CAPABILITY_ITEM_BAUBLE.cast((IBauble)stack.getItem())
+						: null;
 			}
 		});
 	}


### PR DESCRIPTION
Hi Azanor, 
This feature was requested by @darkhax in #183  a while ago.

This PR replaces the whole IBauble item logic with a capability variant. I've added some backwards compatibility code that allows using IBauble as an interface for an Item as well as a capability.

* Registered IBauble as a capability `CAPABILITY_ITEM_BAUBLE`
* Replaced all `(IBauble)itemStack.getItem()` calls with `itemStack.getCapability()`
* Added compatibility event handler that adds the IBauble capability to all items, that implement the IBauble interface

> Note: I did see a lot of null checks for Itemstacks. These checks are always false, due to the Itemstack changes in 1.11.2. I did not refactor that code to reduce the amount of changes done by this PR.

This code has been successfuly tested with Botania 1.11.2-r1.9-343. I've also tested some custom capability that adds IBauble to the minecraft potions, [an example can be found here](https://gist.github.com/Xalcon/9a6473329b50965674b4c59f7886ec07).

I did  not do any ports to 1.10.2 or below yet since I'd like to get some feedback on this code first :)