### PR TITLE
Fixed some GUI bugs/issues and cleaned up some code.

### DIFF
--- a/src/main/java/baubles/client/ClientEventHandler.java
+++ b/src/main/java/baubles/client/ClientEventHandler.java
@@ -29,7 +29,7 @@ public class ClientEventHandler
 	public void playerTick(PlayerTickEvent event) {
 		if (event.side == Side.CLIENT && event.phase == Phase.START ) {
 			if (ClientProxy.KEY_BAUBLES.isPressed() && FMLClientHandler.instance().getClient().inGameHasFocus) {
-					PacketHandler.INSTANCE.sendToServer(new PacketOpenBaublesInventory(event.player));
+					PacketHandler.INSTANCE.sendToServer(new PacketOpenBaublesInventory());
 			}
 		}
 	}

--- a/src/main/java/baubles/client/ClientProxy.java
+++ b/src/main/java/baubles/client/ClientProxy.java
@@ -35,7 +35,7 @@ public class ClientProxy extends CommonProxy {
 	public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
 		if (world instanceof WorldClient) {
 			switch (ID) {
-				case Baubles.GUI: return new GuiPlayerExpanded(player);
+				case Baubles.GUI: return new GuiPlayerExpanded(player, x, y);
 			}
 		}
 		return null;

--- a/src/main/java/baubles/client/gui/GuiBaublesButton.java
+++ b/src/main/java/baubles/client/gui/GuiBaublesButton.java
@@ -20,8 +20,7 @@ public class GuiBaublesButton extends GuiButton {
 
 	@Override
 	public boolean mousePressed(Minecraft mc, int mouseX, int mouseY) {
-		int potionShift = getPotionShift(mc);
-		return super.mousePressed(mc, mouseX - potionShift, mouseY);
+		return super.mousePressed(mc, mouseX - getPositionShift(mc), mouseY);
 	}
 
 	@Override
@@ -29,31 +28,31 @@ public class GuiBaublesButton extends GuiButton {
 	{
 		if (this.visible)
 		{
-			int potionShift = getPotionShift(mc);
+			int positionShift = getPositionShift(mc);
 
 			FontRenderer fontrenderer = mc.fontRenderer;
 			mc.getTextureManager().bindTexture(GuiPlayerExpanded.background);
 			GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
-			this.hovered = xx >= this.x + potionShift && yy >= this.y &&
-					xx < this.x + this.width + potionShift && yy < this.y + this.height;
+			this.hovered = xx >= this.x + positionShift && yy >= this.y &&
+					xx < this.x + this.width + positionShift && yy < this.y + this.height;
 			int k = this.getHoverState(this.hovered);
 			GlStateManager.enableBlend();
 			GlStateManager.tryBlendFuncSeparate(770, 771, 1, 0);
 			GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
 
 			if (k==1) {
-				this.drawTexturedModalRect(this.x + potionShift, this.y, 200, 48, 10, 10);
+				this.drawTexturedModalRect(this.x + positionShift, this.y, 200, 48, 10, 10);
 			} else {
-				this.drawTexturedModalRect(this.x + potionShift, this.y, 210, 48, 10, 10);
+				this.drawTexturedModalRect(this.x + positionShift, this.y, 210, 48, 10, 10);
 				this.drawCenteredString(fontrenderer, I18n.format(this.displayString, new Object[0]),
-						this.x + 5 + potionShift, this.y + this.height, 0xffffff);
+						this.x + 5 + positionShift, this.y + this.height, 0xffffff);
 			}
 
 			this.mouseDragged(mc, xx, yy);
 		}
 	}
 
-	private int getPotionShift(Minecraft mc) {
+	private int getPositionShift(Minecraft mc) {
 		if (mc.currentScreen instanceof GuiContainer) {
 			GuiContainer guiContainer = (GuiContainer) mc.currentScreen;
 			return guiContainer.getGuiLeft() - this.guiLeft;

--- a/src/main/java/baubles/client/gui/GuiBaublesButton.java
+++ b/src/main/java/baubles/client/gui/GuiBaublesButton.java
@@ -28,10 +28,10 @@ public class GuiBaublesButton extends GuiButton {
 		boolean pressed = super.mousePressed(mc, mouseX - this.parentGui.getGuiLeft(), mouseY);
 		if (pressed) {
 			if (parentGui instanceof GuiInventory) {
-				PacketHandler.INSTANCE.sendToServer(new PacketOpenBaublesInventory(mc.player));
+				PacketHandler.INSTANCE.sendToServer(new PacketOpenBaublesInventory(mouseX, mouseY));
 			} else {
-				mc.displayGuiScreen(new GuiInventory(mc.player));
-				PacketHandler.INSTANCE.sendToServer(new PacketOpenNormalInventory(mc.player));
+				((GuiPlayerExpanded) parentGui).displayNormalInventory();
+				PacketHandler.INSTANCE.sendToServer(new PacketOpenNormalInventory());
 			}
 		}
 		return pressed;

--- a/src/main/java/baubles/client/gui/GuiBaublesButton.java
+++ b/src/main/java/baubles/client/gui/GuiBaublesButton.java
@@ -2,61 +2,65 @@ package baubles.client.gui;
 
 import org.lwjgl.opengl.GL11;
 
+import baubles.common.network.PacketHandler;
+import baubles.common.network.PacketOpenBaublesInventory;
+import baubles.common.network.PacketOpenNormalInventory;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.client.gui.inventory.GuiInventory;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.resources.I18n;
 
 public class GuiBaublesButton extends GuiButton {
 
-	private final int guiLeft;
+	private final GuiContainer parentGui;
 
-	public GuiBaublesButton(int buttonId, int guiLeft, int guiTop, int x, int y, int width, int height, String buttonText) {
-		super(buttonId, guiLeft + x, guiTop + y, width, height, buttonText);
-		this.guiLeft = guiLeft;
+	public GuiBaublesButton(int buttonId, GuiContainer parentGui, int x, int y, int width, int height, String buttonText) {
+		super(buttonId, x, parentGui.getGuiTop() + y, width, height, buttonText);
+		this.parentGui = parentGui;
 	}
 
 	@Override
 	public boolean mousePressed(Minecraft mc, int mouseX, int mouseY) {
-		return super.mousePressed(mc, mouseX - getPositionShift(mc), mouseY);
+		boolean pressed = super.mousePressed(mc, mouseX - this.parentGui.getGuiLeft(), mouseY);
+		if (pressed) {
+			if (parentGui instanceof GuiInventory) {
+				PacketHandler.INSTANCE.sendToServer(new PacketOpenBaublesInventory(mc.player));
+			} else {
+				mc.displayGuiScreen(new GuiInventory(mc.player));
+				PacketHandler.INSTANCE.sendToServer(new PacketOpenNormalInventory(mc.player));
+			}
+		}
+		return pressed;
 	}
 
 	@Override
-	public void drawButton(Minecraft mc, int xx, int yy, float p_191745_4_)
+	public void drawButton(Minecraft mc, int mouseX, int mouseY, float partialTicks)
 	{
 		if (this.visible)
 		{
-			int positionShift = getPositionShift(mc);
+			int x = this.x + this.parentGui.getGuiLeft();
 
 			FontRenderer fontrenderer = mc.fontRenderer;
 			mc.getTextureManager().bindTexture(GuiPlayerExpanded.background);
 			GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
-			this.hovered = xx >= this.x + positionShift && yy >= this.y &&
-					xx < this.x + this.width + positionShift && yy < this.y + this.height;
+			this.hovered = mouseX >= x && mouseY >= this.y && mouseX < x + this.width && mouseY < this.y + this.height;
 			int k = this.getHoverState(this.hovered);
 			GlStateManager.enableBlend();
 			GlStateManager.tryBlendFuncSeparate(770, 771, 1, 0);
 			GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
 
 			if (k==1) {
-				this.drawTexturedModalRect(this.x + positionShift, this.y, 200, 48, 10, 10);
+				this.drawTexturedModalRect(x, this.y, 200, 48, 10, 10);
 			} else {
-				this.drawTexturedModalRect(this.x + positionShift, this.y, 210, 48, 10, 10);
-				this.drawCenteredString(fontrenderer, I18n.format(this.displayString, new Object[0]),
-						this.x + 5 + positionShift, this.y + this.height, 0xffffff);
+				this.drawTexturedModalRect(x, this.y, 210, 48, 10, 10);
+				this.drawCenteredString(fontrenderer, I18n.format(this.displayString), x + 5, this.y + this.height, 0xffffff);
 			}
 
-			this.mouseDragged(mc, xx, yy);
+			this.mouseDragged(mc, mouseX, mouseY);
 		}
-	}
-
-	private int getPositionShift(Minecraft mc) {
-		if (mc.currentScreen instanceof GuiContainer) {
-			GuiContainer guiContainer = (GuiContainer) mc.currentScreen;
-			return guiContainer.getGuiLeft() - this.guiLeft;
-		}
-		return 0;
 	}
 }

--- a/src/main/java/baubles/client/gui/GuiBaublesButton.java
+++ b/src/main/java/baubles/client/gui/GuiBaublesButton.java
@@ -53,12 +53,15 @@ public class GuiBaublesButton extends GuiButton {
 			GlStateManager.tryBlendFuncSeparate(770, 771, 1, 0);
 			GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
 
+			GlStateManager.pushMatrix();
+			GlStateManager.translate(0, 0, 200);
 			if (k==1) {
 				this.drawTexturedModalRect(x, this.y, 200, 48, 10, 10);
 			} else {
 				this.drawTexturedModalRect(x, this.y, 210, 48, 10, 10);
 				this.drawCenteredString(fontrenderer, I18n.format(this.displayString), x + 5, this.y + this.height, 0xffffff);
 			}
+			GlStateManager.popMatrix();
 
 			this.mouseDragged(mc, mouseX, mouseY);
 		}

--- a/src/main/java/baubles/client/gui/GuiEvents.java
+++ b/src/main/java/baubles/client/gui/GuiEvents.java
@@ -5,9 +5,6 @@ import net.minecraft.client.gui.inventory.GuiInventory;
 import net.minecraft.client.resources.I18n;
 import net.minecraftforge.client.event.GuiScreenEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import baubles.common.network.PacketHandler;
-import baubles.common.network.PacketOpenBaublesInventory;
-import baubles.common.network.PacketOpenNormalInventory;
 
 public class GuiEvents {
 
@@ -16,25 +13,8 @@ public class GuiEvents {
 
 		if (event.getGui() instanceof GuiInventory || event.getGui() instanceof GuiPlayerExpanded) {
 			GuiContainer gui = (GuiContainer) event.getGui();
-			event.getButtonList().add(new GuiBaublesButton(55, gui.getGuiLeft(), gui.getGuiTop(), 64, 9, 10, 10,
-					I18n.format((event.getGui() instanceof GuiInventory)?"button.baubles":"button.normal", new Object[0])));
-		}
-	}
-
-	@SubscribeEvent
-	public void guiPostAction(GuiScreenEvent.ActionPerformedEvent.Post event) {
-
-		if (event.getGui() instanceof GuiInventory) {
-			if (event.getButton().id == 55) {
-				PacketHandler.INSTANCE.sendToServer(new PacketOpenBaublesInventory(event.getGui().mc.player));
-			}
-		}
-
-		if (event.getGui() instanceof GuiPlayerExpanded) {
-			if (event.getButton().id == 55) {
-				event.getGui().mc.displayGuiScreen(new GuiInventory(event.getGui().mc.player));
-				PacketHandler.INSTANCE.sendToServer(new PacketOpenNormalInventory(event.getGui().mc.player));
-			}
+			event.getButtonList().add(new GuiBaublesButton(55, gui, 64, 9, 10, 10,
+					I18n.format((event.getGui() instanceof GuiInventory) ? "button.baubles" : "button.normal")));
 		}
 	}
 }

--- a/src/main/java/baubles/client/gui/GuiPlayerExpanded.java
+++ b/src/main/java/baubles/client/gui/GuiPlayerExpanded.java
@@ -1,20 +1,16 @@
 package baubles.client.gui;
 
 import java.io.IOException;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.achievement.GuiStats;
 import net.minecraft.client.gui.inventory.GuiInventory;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.InventoryEffectRenderer;
-import net.minecraft.client.renderer.OpenGlHelper;
-import net.minecraft.client.renderer.RenderHelper;
-import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.resources.I18n;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Slot;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.relauncher.ReflectionHelper;
 import baubles.client.ClientProxy;
 import baubles.common.container.ContainerPlayerExpanded;
 
@@ -28,10 +24,12 @@ public class GuiPlayerExpanded extends InventoryEffectRenderer {
 	/** The old y position of the mouse pointer */
 	private float oldMouseY;
 
-	public GuiPlayerExpanded(EntityPlayer player)
+	public GuiPlayerExpanded(EntityPlayer player, int mouseX, int mouseY)
 	{
 		super(new ContainerPlayerExpanded(player.inventory, !player.getEntityWorld().isRemote, player));
 		this.allowUserInput = true;
+		oldMouseX = mouseX;
+		oldMouseY = mouseY;
 	}
 
 	/**
@@ -118,5 +116,12 @@ public class GuiPlayerExpanded extends InventoryEffectRenderer {
 			this.mc.player.closeScreen();
 		} else
 		super.keyTyped(par1, par2);
+	}
+
+	public void displayNormalInventory()
+	{
+		this.mc.displayGuiScreen(new GuiInventory(this.mc.player));
+		ReflectionHelper.setPrivateValue(GuiInventory.class, (GuiInventory) this.mc.currentScreen, this.oldMouseX, "oldMouseX", "field_147048_u");
+		ReflectionHelper.setPrivateValue(GuiInventory.class, (GuiInventory) this.mc.currentScreen, this.oldMouseY, "oldMouseY", "field_147047_v");
 	}
 }

--- a/src/main/java/baubles/client/gui/GuiPlayerExpanded.java
+++ b/src/main/java/baubles/client/gui/GuiPlayerExpanded.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.achievement.GuiStats;
+import net.minecraft.client.gui.inventory.GuiInventory;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.InventoryEffectRenderer;
 import net.minecraft.client.renderer.OpenGlHelper;
@@ -97,48 +98,7 @@ public class GuiPlayerExpanded extends InventoryEffectRenderer {
 			}
 		}
 
-		drawPlayerModel(k + 51, l + 75, 30, (float)(k + 51) - this.xSizeFloat, (float)(l + 75 - 50) - this.ySizeFloat, this.mc.player);
-	}
-
-	public static void drawPlayerModel(int x, int y, int scale, float yaw, float pitch, EntityLivingBase playerdrawn)
-	{
-		GlStateManager.enableColorMaterial();
-		GlStateManager.pushMatrix();
-		GlStateManager.translate((float)x, (float)y, 50.0F);
-		GlStateManager.scale((float)(-scale), (float)scale, (float)scale);
-		GlStateManager.rotate(180.0F, 0.0F, 0.0F, 1.0F);
-		float f2 = playerdrawn.renderYawOffset;
-		float f3 = playerdrawn.rotationYaw;
-		float f4 = playerdrawn.rotationPitch;
-		float f5 = playerdrawn.prevRotationYawHead;
-		float f6 = playerdrawn.rotationYawHead;
-		GlStateManager.rotate(135.0F, 0.0F, 1.0F, 0.0F);
-		RenderHelper.enableStandardItemLighting();
-		GlStateManager.rotate(-135.0F, 0.0F, 1.0F, 0.0F);
-		GlStateManager.rotate(-((float)Math.atan((double)(pitch / 40.0F))) * 20.0F, 1.0F, 0.0F, 0.0F);
-		playerdrawn.renderYawOffset = (float)Math.atan((double)(yaw / 40.0F)) * 20.0F;
-		playerdrawn.rotationYaw = (float)Math.atan((double)(yaw / 40.0F)) * 40.0F;
-		playerdrawn.rotationPitch = -((float)Math.atan((double)(pitch / 40.0F))) * 20.0F;
-		playerdrawn.rotationYawHead = playerdrawn.rotationYaw;
-		playerdrawn.prevRotationYawHead = playerdrawn.rotationYaw;
-		GlStateManager.translate(0.0F, 0.0F, 0.0F);
-		RenderManager renderManager = Minecraft.getMinecraft().getRenderManager();
-		renderManager.setPlayerViewY(180.0F);
-		renderManager.setRenderShadow(false);
-		renderManager.doRenderEntity(playerdrawn, 0.0D, 0.0D, 0.0D, 0.0F, 1.0F, false);
-
-		renderManager.setRenderShadow(true);
-		playerdrawn.renderYawOffset = f2;
-		playerdrawn.rotationYaw = f3;
-		playerdrawn.rotationPitch = f4;
-		playerdrawn.prevRotationYawHead = f5;
-		playerdrawn.rotationYawHead = f6;
-		GlStateManager.popMatrix();
-		RenderHelper.disableStandardItemLighting();
-		GlStateManager.disableRescaleNormal();
-		GlStateManager.setActiveTexture(OpenGlHelper.lightmapTexUnit);
-		GlStateManager.disableTexture2D();
-		GlStateManager.setActiveTexture(OpenGlHelper.defaultTexUnit);
+		GuiInventory.drawEntityOnScreen(k + 51, l + 75, 30, (float)(k + 51) - this.xSizeFloat, (float)(l + 75 - 50) - this.ySizeFloat, this.mc.player);
 	}
 
 	@Override

--- a/src/main/java/baubles/client/gui/GuiPlayerExpanded.java
+++ b/src/main/java/baubles/client/gui/GuiPlayerExpanded.java
@@ -23,14 +23,10 @@ public class GuiPlayerExpanded extends InventoryEffectRenderer {
 	public static final ResourceLocation background =
 			new ResourceLocation("baubles","textures/gui/expanded_inventory.png");
 
-	/**
-	 * x size of the inventory window in pixels. Defined as  float, passed as int
-	 */
-	private float xSizeFloat;
-	/**
-	 * y size of the inventory window in pixels. Defined as  float, passed as int.
-	 */
-	private float ySizeFloat;
+	/** The old x position of the mouse pointer */
+	private float oldMouseX;
+	/** The old y position of the mouse pointer */
+	private float oldMouseY;
 
 	public GuiPlayerExpanded(EntityPlayer player)
 	{
@@ -75,8 +71,8 @@ public class GuiPlayerExpanded extends InventoryEffectRenderer {
 	{
 		this.drawDefaultBackground();
 		super.drawScreen(mouseX, mouseY, partialTicks);
-		this.xSizeFloat = (float) mouseX;
-		this.ySizeFloat = (float) mouseY;
+		this.oldMouseX = (float) mouseX;
+		this.oldMouseY = (float) mouseY;
 		this.renderHoveredToolTip(mouseX, mouseY);
 	}
 
@@ -98,7 +94,7 @@ public class GuiPlayerExpanded extends InventoryEffectRenderer {
 			}
 		}
 
-		GuiInventory.drawEntityOnScreen(k + 51, l + 75, 30, (float)(k + 51) - this.xSizeFloat, (float)(l + 75 - 50) - this.ySizeFloat, this.mc.player);
+		GuiInventory.drawEntityOnScreen(k + 51, l + 75, 30, (float)(k + 51) - this.oldMouseX, (float)(l + 75 - 50) - this.oldMouseY, this.mc.player);
 	}
 
 	@Override

--- a/src/main/java/baubles/client/gui/GuiPlayerExpanded.java
+++ b/src/main/java/baubles/client/gui/GuiPlayerExpanded.java
@@ -32,6 +32,11 @@ public class GuiPlayerExpanded extends InventoryEffectRenderer {
 		oldMouseY = mouseY;
 	}
 
+	private void resetGuiLeft()
+	{
+		this.guiLeft = (this.width - this.xSize) / 2;
+	}
+
 	/**
 	 * Called from the main game loop to update the screen.
 	 */
@@ -39,7 +44,8 @@ public class GuiPlayerExpanded extends InventoryEffectRenderer {
 	public void updateScreen()
 	{
 		((ContainerPlayerExpanded)inventorySlots).baubles.setEventBlock(false);
-		this.updateActivePotionEffects();
+		updateActivePotionEffects();
+		resetGuiLeft();
 	}
 
 	/**
@@ -50,6 +56,7 @@ public class GuiPlayerExpanded extends InventoryEffectRenderer {
 	{
 		this.buttonList.clear();
 		super.initGui();
+		resetGuiLeft();
 	}
 
 	/**

--- a/src/main/java/baubles/common/network/PacketOpenBaublesInventory.java
+++ b/src/main/java/baubles/common/network/PacketOpenBaublesInventory.java
@@ -26,7 +26,7 @@ public class PacketOpenBaublesInventory implements IMessage, IMessageHandler<Pac
 		IThreadListener mainThread = (WorldServer) ctx.getServerHandler().player.world;
 		mainThread.addScheduledTask(new Runnable(){ public void run() {
 			ctx.getServerHandler().player.openContainer.onContainerClosed(ctx.getServerHandler().player);
-			ctx.getServerHandler().player.openGui(Baubles.instance, Baubles.GUI, ctx.getServerHandler().player.world, (int)ctx.getServerHandler().player.posX, (int)ctx.getServerHandler().player.posY, (int)ctx.getServerHandler().player.posZ);
+			ctx.getServerHandler().player.openGui(Baubles.instance, Baubles.GUI, ctx.getServerHandler().player.world, 0, 0, 0);
 		}});
 		return null;
 	}

--- a/src/main/java/baubles/common/network/PacketOpenBaublesInventory.java
+++ b/src/main/java/baubles/common/network/PacketOpenBaublesInventory.java
@@ -1,6 +1,5 @@
 package baubles.common.network;
 
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.IThreadListener;
 import net.minecraft.world.WorldServer;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
@@ -11,22 +10,33 @@ import io.netty.buffer.ByteBuf;
 
 public class PacketOpenBaublesInventory implements IMessage, IMessageHandler<PacketOpenBaublesInventory, IMessage> {
 
+	int mouseX, mouseY;
+
 	public PacketOpenBaublesInventory() {}
 
-	public PacketOpenBaublesInventory(EntityPlayer player) {}
+	public PacketOpenBaublesInventory(int mouseX, int mouseY) {
+		this.mouseX = mouseX;
+		this.mouseY = mouseY;
+	}
 
 	@Override
-	public void toBytes(ByteBuf buffer) {}
+	public void toBytes(ByteBuf buffer) {
+		buffer.writeInt(mouseX);
+		buffer.writeInt(mouseY);
+	}
 
 	@Override
-	public void fromBytes(ByteBuf buffer) {}
+	public void fromBytes(ByteBuf buffer) {
+		mouseX = buffer.readInt();
+		mouseY = buffer.readInt();
+	}
 
 	@Override
 	public IMessage onMessage(PacketOpenBaublesInventory message, MessageContext ctx) {
 		IThreadListener mainThread = (WorldServer) ctx.getServerHandler().player.world;
 		mainThread.addScheduledTask(new Runnable(){ public void run() {
 			ctx.getServerHandler().player.openContainer.onContainerClosed(ctx.getServerHandler().player);
-			ctx.getServerHandler().player.openGui(Baubles.instance, Baubles.GUI, ctx.getServerHandler().player.world, 0, 0, 0);
+			ctx.getServerHandler().player.openGui(Baubles.instance, Baubles.GUI, ctx.getServerHandler().player.world, message.mouseX, message.mouseY, 0);
 		}});
 		return null;
 	}

--- a/src/main/java/baubles/common/network/PacketOpenNormalInventory.java
+++ b/src/main/java/baubles/common/network/PacketOpenNormalInventory.java
@@ -1,7 +1,6 @@
 package baubles.common.network;
 
 import io.netty.buffer.ByteBuf;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.IThreadListener;
 import net.minecraft.world.WorldServer;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
@@ -11,8 +10,6 @@ import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
 public class PacketOpenNormalInventory implements IMessage, IMessageHandler<PacketOpenNormalInventory, IMessage> {
 
 	public PacketOpenNormalInventory() {}
-
-	public PacketOpenNormalInventory(EntityPlayer player) {}
 
 	@Override
 	public void toBytes(ByteBuf buffer) {}


### PR DESCRIPTION
In addition to a bit of cleanup/optimization, this PR fixes the following bugs/issues:
1. The rendering of the baubles button texture and text behind the player in 1.12 (#222).
2. The failure to position the baubles GUI as GuiInventory positions itself in 1.12, when potion effects are being rendered.
3. A minor (yet longstanding and surprisingly unreported) bug where the player model jerks when transitioning between inventories.

I have versions of these changes (sans the 1.12-only ones) that can be merged into your 1.10.2 and 1.11 branches. Let me know if you want me to open PRs for either/both of them.