### PR TITLE
Optimization of GUI transitioning bug fix

### DIFF
--- a/src/main/java/baubles/client/ClientProxy.java
+++ b/src/main/java/baubles/client/ClientProxy.java
@@ -35,7 +35,7 @@ public class ClientProxy extends CommonProxy {
 	public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
 		if (world instanceof WorldClient) {
 			switch (ID) {
-				case Baubles.GUI: return new GuiPlayerExpanded(player, x, y);
+				case Baubles.GUI: return new GuiPlayerExpanded(player);
 			}
 		}
 		return null;

--- a/src/main/java/baubles/client/gui/GuiBaublesButton.java
+++ b/src/main/java/baubles/client/gui/GuiBaublesButton.java
@@ -28,7 +28,7 @@ public class GuiBaublesButton extends GuiButton {
 		boolean pressed = super.mousePressed(mc, mouseX - this.parentGui.getGuiLeft(), mouseY);
 		if (pressed) {
 			if (parentGui instanceof GuiInventory) {
-				PacketHandler.INSTANCE.sendToServer(new PacketOpenBaublesInventory(mouseX, mouseY));
+				PacketHandler.INSTANCE.sendToServer(new PacketOpenBaublesInventory());
 			} else {
 				((GuiPlayerExpanded) parentGui).displayNormalInventory();
 				PacketHandler.INSTANCE.sendToServer(new PacketOpenNormalInventory());

--- a/src/main/java/baubles/client/gui/GuiPlayerExpanded.java
+++ b/src/main/java/baubles/client/gui/GuiPlayerExpanded.java
@@ -24,12 +24,10 @@ public class GuiPlayerExpanded extends InventoryEffectRenderer {
 	/** The old y position of the mouse pointer */
 	private float oldMouseY;
 
-	public GuiPlayerExpanded(EntityPlayer player, int mouseX, int mouseY)
+	public GuiPlayerExpanded(EntityPlayer player)
 	{
 		super(new ContainerPlayerExpanded(player.inventory, !player.getEntityWorld().isRemote, player));
 		this.allowUserInput = true;
-		oldMouseX = mouseX;
-		oldMouseY = mouseY;
 	}
 
 	private void resetGuiLeft()
@@ -75,9 +73,9 @@ public class GuiPlayerExpanded extends InventoryEffectRenderer {
 	public void drawScreen(int mouseX, int mouseY, float partialTicks)
 	{
 		this.drawDefaultBackground();
-		super.drawScreen(mouseX, mouseY, partialTicks);
 		this.oldMouseX = (float) mouseX;
 		this.oldMouseY = (float) mouseY;
+		super.drawScreen(mouseX, mouseY, partialTicks);
 		this.renderHoveredToolTip(mouseX, mouseY);
 	}
 

--- a/src/main/java/baubles/client/gui/GuiPlayerExpanded.java
+++ b/src/main/java/baubles/client/gui/GuiPlayerExpanded.java
@@ -125,8 +125,9 @@ public class GuiPlayerExpanded extends InventoryEffectRenderer {
 
 	public void displayNormalInventory()
 	{
-		this.mc.displayGuiScreen(new GuiInventory(this.mc.player));
-		ReflectionHelper.setPrivateValue(GuiInventory.class, (GuiInventory) this.mc.currentScreen, this.oldMouseX, "oldMouseX", "field_147048_u");
-		ReflectionHelper.setPrivateValue(GuiInventory.class, (GuiInventory) this.mc.currentScreen, this.oldMouseY, "oldMouseY", "field_147047_v");
+		GuiInventory gui = new GuiInventory(this.mc.player);
+		ReflectionHelper.setPrivateValue(GuiInventory.class, gui, this.oldMouseX, "oldMouseX", "field_147048_u");
+		ReflectionHelper.setPrivateValue(GuiInventory.class, gui, this.oldMouseY, "oldMouseY", "field_147047_v");
+		this.mc.displayGuiScreen(gui);
 	}
 }

--- a/src/main/java/baubles/common/network/PacketOpenBaublesInventory.java
+++ b/src/main/java/baubles/common/network/PacketOpenBaublesInventory.java
@@ -10,33 +10,20 @@ import io.netty.buffer.ByteBuf;
 
 public class PacketOpenBaublesInventory implements IMessage, IMessageHandler<PacketOpenBaublesInventory, IMessage> {
 
-	int mouseX, mouseY;
-
 	public PacketOpenBaublesInventory() {}
 
-	public PacketOpenBaublesInventory(int mouseX, int mouseY) {
-		this.mouseX = mouseX;
-		this.mouseY = mouseY;
-	}
+	@Override
+	public void toBytes(ByteBuf buffer) {}
 
 	@Override
-	public void toBytes(ByteBuf buffer) {
-		buffer.writeInt(mouseX);
-		buffer.writeInt(mouseY);
-	}
-
-	@Override
-	public void fromBytes(ByteBuf buffer) {
-		mouseX = buffer.readInt();
-		mouseY = buffer.readInt();
-	}
+	public void fromBytes(ByteBuf buffer) {}
 
 	@Override
 	public IMessage onMessage(PacketOpenBaublesInventory message, MessageContext ctx) {
 		IThreadListener mainThread = (WorldServer) ctx.getServerHandler().player.world;
 		mainThread.addScheduledTask(new Runnable(){ public void run() {
 			ctx.getServerHandler().player.openContainer.onContainerClosed(ctx.getServerHandler().player);
-			ctx.getServerHandler().player.openGui(Baubles.instance, Baubles.GUI, ctx.getServerHandler().player.world, message.mouseX, message.mouseY, 0);
+			ctx.getServerHandler().player.openGui(Baubles.instance, Baubles.GUI, ctx.getServerHandler().player.world, 0, 0, 0);
 		}});
 		return null;
 	}


### PR DESCRIPTION
Well, I feel stupid. I just realized that the GUI transitioning bug fix in #224 was needlessly roundabout. I initialized the mouse position when opening GuiPlayerExpanded by passing the position to the packet, and eventually all the way through to its constructor when created in the GUI handler...

All I actually needed to do was just move the super call in drawScreen below the setting of the mouse position floats used to draw the player... oops.

Also, I was assuming that the displaying of the GuiInventory was successful and casting the player's currentScreen to it, rather then just setting the mouse position on the newly created object. There is no longer a potential for a ClassCastException crash.