### PR TITLE
Fix syncing when players are tracked

### DIFF
--- a/src/main/java/baubles/common/network/PacketSync.java
+++ b/src/main/java/baubles/common/network/PacketSync.java
@@ -22,12 +22,10 @@ public class PacketSync implements IMessage {
 
 	public PacketSync() {}
 
-	public PacketSync(EntityPlayer p, int slot) {
-		IBaublesItemHandler baubles = BaublesApi.getBaublesHandler(p);
+	public PacketSync(EntityPlayer p, int slot, ItemStack bauble) {
 		this.slot = (byte) slot;
-		this.bauble = baubles.getStackInSlot(slot);
+		this.bauble = bauble;
 		this.playerId = p.getEntityId();
-		baubles.setChanged(slot,false);
 	}
 
 	@Override


### PR DESCRIPTION
This PR fixes baubles not syncing when a player gets in tracking range of another as well as remove the unnecessary sending of sync packets for players to players who aren't being tracked.