### PR TITLE
Added back the old PacketSync constructor and deprecated it.

### DIFF
--- a/src/main/java/baubles/common/network/PacketSync.java
+++ b/src/main/java/baubles/common/network/PacketSync.java
@@ -22,6 +22,16 @@ public class PacketSync implements IMessage {
 
 	public PacketSync() {}
 
+	/**
+	 * Instanciate the PacketSync the old way.
+	 *
+	 * @deprecated use {@link #PacketSync(EntityPlayer, int, ItemStack)} instead.
+	 */
+	@Deprecated
+	public PacketSync(EntityPlayer p, int slot) {
+	    this(p, slot, BaublesApi.getBaublesHandler(p).getStackInSlot(slot));
+	}
+
 	public PacketSync(EntityPlayer p, int slot, ItemStack bauble) {
 		this.slot = (byte) slot;
 		this.bauble = bauble;


### PR DESCRIPTION
This is to fix the problems with Botania in mod packs until Botania is fixed in the mod pack.

This is tested on a user which had the problem and couldn't login anymore, this allows him to login