### PR TITLE
[Baubles] Mod compatibility with Public Gui Announcement

### DIFF
--- a/src/main/resources/assets/baubles/load_screens/mod_compat_pga.json
+++ b/src/main/resources/assets/baubles/load_screens/mod_compat_pga.json
@@ -1,0 +1,7 @@
+{
+	"screens" : [{
+			"COMMENT" : "BAUBLES SUPPORT", 
+			"class" : "baubles.common.container.ContainerPlayerExpanded", 
+			"texture" : "baubles:textures/gui/expanded_inventory.png"
+		}]
+}


### PR DESCRIPTION
the PGA :
https://www.curseforge.com/minecraft/mc-mods/public-gui-announcement

The Wiki on how these JSON files work :
https://github.com/ArtixAllMighty/PublicGuiAnnouncement/wiki/Add-Mod-Compatibility

In this PR is contained one json file to add compatibility with the mod Public Gui Announcement.
I wanted to ship the compat at first with my mod, but it would be better if the author maintains it himself. (in case of path and name changes as well addition or removal from screens).

I hereby give you all files needed to add compatibility to my mod. There is nothing else left to do apart from merging the PR.

If you have any other question, I'd be happy to answer !